### PR TITLE
feat: Evitar edición por parte de jefe de departamento  de actividades complementarias ya aceptadas

### DIFF
--- a/odoo/addons/actividades_complementarias/data/demo_data.xml
+++ b/odoo/addons/actividades_complementarias/data/demo_data.xml
@@ -246,7 +246,7 @@
         <field name="periodo" ref="actividades_complementarias.periodo_2025_A"/>
         <field name="jefe_departamento_id" ref="user_jefe_sistemas"/>
         <field name="responsable_actividad_id" ref="user_responsable_1"/>
-        <field name="fecha_inicio">2026-04-01</field>
+        <field name="fecha_inicio">2026-06-09</field>
         <field name="fecha_fin">2026-07-01</field>
         <field name="cantidad_horas">60</field>
         <field name="creditos">0.5</field>
@@ -263,7 +263,7 @@
         <field name="periodo" ref="actividades_complementarias.periodo_2025_A"/>
         <field name="jefe_departamento_id" ref="user_jefe_sistemas"/>
         <field name="responsable_actividad_id" ref="user_responsable_1"/>
-        <field name="fecha_inicio">2026-04-05</field>
+        <field name="fecha_inicio">2026-07-14</field>
         <field name="fecha_fin">2026-08-05</field>
         <field name="cantidad_horas">80</field>
         <field name="creditos">1.0</field>
@@ -282,7 +282,7 @@
         <field name="periodo" ref="actividades_complementarias.periodo_2025_A"/>
         <field name="jefe_departamento_id" ref="user_jefe_sistemas"/>
         <field name="responsable_actividad_id" ref="user_responsable_2"/>
-        <field name="fecha_inicio">2026-04-14</field>
+        <field name="fecha_inicio">2026-06-01</field>
         <field name="fecha_fin">2026-06-30</field>
         <field name="cantidad_horas">40</field>
         <field name="creditos">1.0</field>
@@ -299,7 +299,7 @@
         <field name="periodo" ref="actividades_complementarias.periodo_2025_A"/>
         <field name="jefe_departamento_id" ref="user_jefe_biologia"/>
         <field name="responsable_actividad_id" ref="user_responsable_3"/>
-        <field name="fecha_inicio">2026-04-20</field>
+        <field name="fecha_inicio">2026-05-20</field>
         <field name="fecha_fin">2026-06-20</field>
         <field name="cantidad_horas">30</field>
         <field name="creditos">0.5</field>

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -396,7 +396,6 @@ class Actividad(models.Model):
                       'por el Comité Académico. No puede modificarla durante la revisión.')
                     % rec.name
                 )
-            
             # ── Regla 3: En catálogo / Pendiente de Inicio ──
             if rec.en_catalogo or rec.estado_code in ('aprobada', 'pendiente_inicio'):
                 campos_permitidos = {'responsable_actividad_id', 'fecha_inicio', 'fecha_fin', 'horario'}

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -161,7 +161,8 @@ class Actividad(models.Model):
     permisos_actividad_pendiente_inicio = fields.Boolean(
         string='Solo Responsable, Fechas y Horas Editables',
         compute='_compute_permisos_edicion',
-        help='True cuando el JD solo puede modificar los campos Responsable de Actividad, Fecha de Inicio, Fecha de Finalización y Horario por Día.',
+        help='True cuando el JD solo puede modificar los campos Responsable de Actividad, Fecha de Inicio, ' \
+        'Fecha de Finalización y Horario por Día.',
     )
     permisos_actividad_en_curso = fields.Boolean(
         string='Solo Responsable Editable',
@@ -395,7 +396,7 @@ class Actividad(models.Model):
                       'por el Comité Académico. No puede modificarla durante la revisión.')
                     % rec.name
                 )
-            
+                        
             # ── Regla 3: En catálogo / Pendiente de Inicio ──
             if rec.en_catalogo or rec.estado_code in ('aprobada', 'pendiente_inicio'):
                 campos_permitidos = {'responsable_actividad_id', 'fecha_inicio', 'fecha_fin', 'horario'}
@@ -403,8 +404,9 @@ class Actividad(models.Model):
                 if campos_no_permitidos:
                     raise UserError(
                         _('La actividad "%s" está en aprobada o pendiente de inicio. '
-                          'En este estado únicamente puede modificar '
-                          '"Responsable de Actividad", "Fecha de Inicio", "Fecha de Finalización", y "Horario por Día".')
+                          'En este estado únicamente puede modificar'
+                          '"Responsable de Actividad", "Fecha de Inicio", "Fecha de Finalización", '
+                          'y "Horario por Día".')
                         % rec.name
                     )
 

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields, api
-from odoo.exceptions import ValidationError
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError, UserError
 from datetime import date
 
 
@@ -9,6 +9,18 @@ class Actividad(models.Model):
     _description = 'Actividad Complementaria'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _order = 'fecha_inicio desc'
+
+    # Campos que el JD nunca puede escribir directamente (gestionados por el sistema).
+    # Las acciones de negocio que los necesiten deben usar:
+    #   self.with_context(bypass_edit_protection=True).write(vals)
+    _CAMPOS_AUTO_JD = frozenset({
+        'jefe_departamento_id',
+        'departamento_id',
+        'estado_id',
+        'en_catalogo',
+        'jd_firmo',
+        'responsable_firmo',
+    })
 
     # ── Identificación ──────────────────────────────────────────────────────
     name = fields.Char(
@@ -145,14 +157,29 @@ class Actividad(models.Model):
             'sin pasar por el Comité Académico. Puede dejarse en blanco para quitarlo.',
     )
 
+    # ── Flags de permisos de edición (por estado) ─
+    permisos_actividad_pendiente_inicio = fields.Boolean(
+        string='Solo Responsable, Fechas y Horas Editables',
+        compute='_compute_permisos_edicion',
+        help='True cuando el JD solo puede modificar los campos Responsable de Actividad, Fecha de Inicio, Fecha de Finalización y Horario por Día.',
+    )
+    permisos_actividad_en_curso = fields.Boolean(
+        string='Solo Responsable Editable',
+        compute='_compute_permisos_edicion',
+        help='True cuando el JD solo puede modificar el campo Responsable de Actividad.',
+    )
+    permisos_actividad_finalizada = fields.Boolean(
+        string='Solo Lectura',
+        compute='_compute_permisos_edicion',
+        help='True cuando el usuario en sesión no puede editar ningún campo del formulario.',
+    )
+
     # ────────────────────────────────────────────────────────────────────────
     # Computes
     # ────────────────────────────────────────────────────────────────────────
 
     @api.depends('tipo_actividad_id')
     def _compute_tipo_es_nueva(self):
-        """True cuando el tipo de actividad es 'Nueva (Propuesta)',
-        para ocultar el campo Actividades Predefinidas en ese caso."""
         for rec in self:
             rec.tipo_es_nueva = (
                 rec.tipo_actividad_id and
@@ -200,14 +227,12 @@ class Actividad(models.Model):
             if not rec.jefe_departamento_id:
                 rec.departamento_id = False
                 continue
-            # Primero buscar en el catálogo de departamentos (jefe_id)
             depto = self.env['actividad.departamento'].search(
                 [('jefe_id', '=', rec.jefe_departamento_id.id)], limit=1
             )
             if depto:
                 rec.departamento_id = depto
             else:
-                # Fallback: buscar en el registro de permisos del empleado
                 emp = self.env['actividad.empleado.permiso'].search(
                     [('user_id', '=', rec.jefe_departamento_id.id)], limit=1
                 )
@@ -223,6 +248,184 @@ class Actividad(models.Model):
         for rec in self:
             rec.alumno_count = len(rec.alumno_ids)
 
+    @api.depends('estado_code', 'en_catalogo', 'jefe_departamento_id')
+    def _compute_permisos_edicion(self):
+        """
+        Calcula los flags de solo-lectura para el formulario según el estado
+        del registro y el rol del usuario en sesión.
+
+        Las reglas implementadas son:
+        1. Finalizada             → permisos_actividad_finalizada=True para TODOS (incluido admin).
+        2. Admin (no finalizada)  → sin restricciones de formulario.
+        3. JD dueño, en_revision  → permisos_actividad_finalizada=True.
+        4. JD dueño, pendiente de inicio → permisos_actividad_pendiente_inicio = True
+        5. JD dueño, en_catalogo
+           o pendiente_inicio
+           o en_curso             → permisos_actividad_en_curso=True.
+        6. JD dueño, rechazada
+           o aprobada             → sin restricciones (puede editar campos no-auto).
+        7. JD viendo actividad
+           de otro JD             → permisos_actividad_finalizada=True (solo puede ver catálogo).
+        8. Cualquier otro rol     → permisos_actividad_finalizada=True.
+        """
+        is_admin = self.env.user.has_group(
+            'actividades_complementarias.group_admin_actividades'
+        )
+        is_jd = self.env.user.has_group(
+            'actividades_complementarias.group_jefe_departamento'
+        )
+
+        for rec in self:
+            # Regla 1 (absoluta): finalizada → nadie edita
+            if rec.estado_code == 'finalizada':
+                rec.permisos_actividad_finalizada = True
+                rec.permisos_actividad_pendiente_inicio = False
+                rec.permisos_actividad_en_curso = False
+                continue
+
+            # Admin: sin restricciones de solo-lectura (salvo finalizada)
+            if is_admin:
+                rec.permisos_actividad_finalizada = False
+                rec.permisos_actividad_pendiente_inicio = False
+                rec.permisos_actividad_en_curso = False
+                continue
+
+            if not is_jd:
+                # Otros roles: formulario de solo lectura
+                rec.permisos_actividad_finalizada = True
+                rec.permisos_actividad_pendiente_inicio = False
+                rec.permisos_actividad_en_curso = False
+                continue
+
+            # Usuario es JD (no admin)
+            es_dueno = (rec.jefe_departamento_id.id == self.env.user.id)
+
+            if not es_dueno:
+                # Regla 6: JD viendo actividad de otro JD (solo catálogo accesible via record rule)
+                rec.permisos_actividad_finalizada = True
+                rec.permisos_actividad_pendiente_inicio = False
+                rec.permisos_actividad_en_curso = False
+
+            elif rec.estado_code in ('aprobada', 'pendiente_inicio'):
+                # Regla 4: actividad pendiende de inicio
+                rec.permisos_actividad_finalizada = False
+                rec.permisos_actividad_pendiente_inicio = True
+                rec.permisos_actividad_en_curso = False
+
+            elif rec.estado_code == 'en_revision':
+                # Regla 2/3: propuesta en revisión → JD no puede modificar nada
+                rec.permisos_actividad_finalizada = True
+                rec.permisos_actividad_pendiente_inicio = False
+                rec.permisos_actividad_en_curso = False
+
+            elif rec.en_catalogo or rec.estado_code == 'en_curso':
+                # Regla 3: en catálogo o iniciada → solo responsable_actividad_id
+                rec.permisos_actividad_finalizada = False
+                rec.permisos_actividad_pendiente_inicio = False
+                rec.permisos_actividad_en_curso = True
+
+            else:
+                # Regla 4: rechazada, aprobada u otro estado → acceso completo (no-auto)
+                rec.permisos_actividad_finalizada = False
+                rec.permisos_actividad_pendiente_inicio = False
+                rec.permisos_actividad_en_curso = False
+
+    # ────────────────────────────────────────────────────────────────────────
+    # ORM override: write()
+    # ────────────────────────────────────────────────────────────────────────
+
+    def write(self, vals):
+        """
+        Aplica las reglas de edición según estado y rol del usuario en sesión.
+
+        Para que las acciones de negocio internas (cron, wizards, flujo de trabajo)
+        puedan modificar campos auto-gestionados o registros finalizados, deben usar:
+            self.with_context(bypass_edit_protection=True).write(vals)
+        """
+        # Las acciones internas del sistema omiten la protección
+        if self.env.context.get('bypass_edit_protection'):
+            return super().write(vals)
+
+        is_admin = self.env.user.has_group(
+            'actividades_complementarias.group_admin_actividades'
+        )
+        is_jd = self.env.user.has_group(
+            'actividades_complementarias.group_jefe_departamento'
+        )
+
+        for rec in self:
+            # ── Regla 1: Finalizada → nadie puede modificar (incluido admin) ──
+            if rec.estado_code == 'finalizada':
+                raise UserError(
+                    _('La actividad "%s" está finalizada y no puede ser '
+                      'modificada por ningún usuario.')
+                    % rec.name
+                )
+
+            # Admin: sin restricciones de estado
+            if is_admin:
+                continue
+
+            # Otros roles: se gestionan vía model access / record rules
+            if not is_jd:
+                continue
+
+            # ── A partir de aquí: usuario es JD (no admin) ──
+
+            # ── Regla 5: JD nunca modifica actividades de otro JD ──
+            if rec.jefe_departamento_id.id != self.env.user.id:
+                raise UserError(
+                    _('No tiene permiso para modificar actividades de '
+                      'otros Jefes de Departamento.')
+                )
+
+            # JD no puede escribir directamente campos auto-gestionados
+            campos_auto_solicitados = set(vals.keys()) & self._CAMPOS_AUTO_JD
+            if campos_auto_solicitados:
+                raise UserError(
+                    _('Los siguientes campos son gestionados automáticamente '
+                      'por el sistema y no pueden modificarse directamente: %s.')
+                    % ', '.join(sorted(campos_auto_solicitados))
+                )
+
+            # ── Regla 2: Propuesta en revisión → JD no modifica nada ──
+            if rec.estado_code == 'en_revision':
+                raise UserError(
+                    _('La propuesta de la actividad "%s" está siendo revisada '
+                      'por el Comité Académico. No puede modificarla durante la revisión.')
+                    % rec.name
+                )
+            
+            # ── Regla 3: En catálogo / Pendiente de Inicio ──
+            if rec.en_catalogo or rec.estado_code in ('aprobada', 'pendiente_inicio'):
+                campos_permitidos = {'responsable_actividad_id', 'fecha_inicio', 'fecha_fin', 'horario'}
+                campos_no_permitidos = set(vals.keys()) - campos_permitidos
+                if campos_no_permitidos:
+                    raise UserError(
+                        _('La actividad "%s" está en aprobada o pendiente de inicio. '
+                          'En este estado únicamente puede modificar '
+                          '"Responsable de Actividad", "Fecha de Inicio", "Fecha de Finalización", y "Horario por Día".')
+                        % rec.name
+                    )
+
+            # ── Regla 3: En catálogo / En Curso ──
+            #    Solo se permite modificar responsable_actividad_id
+            if rec.estado_code == 'en_curso':
+                campos_permitidos = {'responsable_actividad_id'}
+                campos_no_permitidos = set(vals.keys()) - campos_permitidos
+                if campos_no_permitidos:
+                    raise UserError(
+                        _('La actividad "%s" está en curso. '
+                          'En este estado únicamente puede modificar '
+                          '"Responsable de Actividad".')
+                        % rec.name
+                    )
+
+            # ── Regla 4: Rechazada → JD puede modificar cualquier campo
+            #    que no sea auto-gestionado (ya validado arriba). ──
+
+        return super().write(vals)
+
     # ────────────────────────────────────────────────────────────────────────
     # Constraints
     # ────────────────────────────────────────────────────────────────────────
@@ -230,7 +433,6 @@ class Actividad(models.Model):
     @api.constrains('fecha_inicio', 'fecha_fin')
     def _check_fechas(self):
         for rec in self:
-            # No validar fechas pasadas cuando se cargan datos de demo o desde el sistema
             if not self.env.context.get('install_demo') and not self.env.context.get('skip_fecha_check'):
                 if rec.fecha_inicio and rec.fecha_inicio < date.today():
                     raise ValidationError('La fecha de inicio no puede ser anterior a hoy.')
@@ -262,6 +464,8 @@ class Actividad(models.Model):
 
     # ────────────────────────────────────────────────────────────────────────
     # Business Logic
+    # Todas las acciones de negocio que escriben campos auto-gestionados
+    # usan with_context(bypass_edit_protection=True) para pasar el guard de write().
     # ────────────────────────────────────────────────────────────────────────
 
     def action_enviar_comite(self):
@@ -272,7 +476,6 @@ class Actividad(models.Model):
                 'Esta actividad ya fue aprobada o está en curso/finalizada. '
                 'No puede ser reenviada al Comité Académico.'
             )
-        # Verificar que no haya propuesta pendiente o aprobada ya
         propuesta_existente = self.env['actividad.propuesta'].search([
             ('actividad_id', '=', self.id),
             ('estado_code', 'in', ('en_revision', 'aprobada')),
@@ -281,7 +484,7 @@ class Actividad(models.Model):
             raise ValidationError('Esta actividad ya tiene una propuesta activa o aprobada en el Comité.')
         estado_revision_solicitud = self.env.ref('actividades_complementarias.estado_solicitud_en_revision')
         estado_en_revision = self.env.ref('actividades_complementarias.estado_en_revision')
-        self.write({'estado_id': estado_en_revision.id})
+        self.with_context(bypass_edit_protection=True).write({'estado_id': estado_en_revision.id})
         self.env['actividad.propuesta'].create({
             'actividad_id': self.id,
             'estado_solicitud_id': estado_revision_solicitud.id,
@@ -290,7 +493,6 @@ class Actividad(models.Model):
             body='Propuesta enviada al Comité Académico para su revisión. '
                  'Se aprobará automáticamente si no hay respuesta en 5 días.'
         )
-        # Abrir la lista de propuestas
         return {
             'type': 'ir.actions.act_window',
             'name': 'Mis Propuestas al Comité',
@@ -301,9 +503,7 @@ class Actividad(models.Model):
         }
 
     def action_enviar_catalogo(self):
-        """Envía la actividad al catálogo.
-        Si tiene actividad_predefinida, se aprueba automáticamente antes de enviar.
-        """
+        """Envía la actividad al catálogo."""
         self.ensure_one()
         if self.estado_code == 'rechazada':
             raise ValidationError(
@@ -314,14 +514,13 @@ class Actividad(models.Model):
                 'Esta actividad ya fue finalizada y no puede ser enviada al catálogo. '
                 'Cree una nueva propuesta de actividad si desea volver a ofertarla.'
             )
-        # Si es predefinida y aún no está en un estado válido, la aprobamos automáticamente
         if self.actividad_predefinida and self.estado_code not in ('aprobada', 'pendiente_inicio', 'en_curso'):
             estado_pendiente = self.env.ref('actividades_complementarias.estado_pendiente_inicio')
-            self.write({'estado_id': estado_pendiente.id})
+            self.with_context(bypass_edit_protection=True).write({'estado_id': estado_pendiente.id})
             self.message_post(body=f'Actividad predefinida ({self.actividad_predefinida}) aprobada automáticamente.')
         if self.estado_code not in ('aprobada', 'pendiente_inicio'):
             raise ValidationError('Solo se pueden enviar al catálogo actividades aprobadas o pendientes de inicio.')
-        self.write({'en_catalogo': True})
+        self.with_context(bypass_edit_protection=True).write({'en_catalogo': True})
         self.message_post(body='Actividad enviada al catálogo.')
 
     def action_iniciar_actividad(self):
@@ -330,7 +529,7 @@ class Actividad(models.Model):
         if self.estado_code not in ('aprobada', 'pendiente_inicio'):
             raise ValidationError('Solo se pueden iniciar actividades aprobadas o pendientes de inicio.')
         estado_en_curso = self.env.ref('actividades_complementarias.estado_en_curso')
-        self.write({'estado_id': estado_en_curso.id})
+        self.with_context(bypass_edit_protection=True).write({'estado_id': estado_en_curso.id})
         self.message_post(body='Actividad iniciada manualmente por el Jefe de Departamento.')
 
     def action_finalizar_actividad(self):
@@ -339,7 +538,10 @@ class Actividad(models.Model):
         if self.estado_code != 'en_curso':
             raise ValidationError('Solo se pueden finalizar actividades que estén en curso.')
         estado_finalizada = self.env.ref('actividades_complementarias.estado_finalizada')
-        self.write({'estado_id': estado_finalizada.id, 'en_catalogo': False})
+        self.with_context(bypass_edit_protection=True).write({
+            'estado_id': estado_finalizada.id,
+            'en_catalogo': False,
+        })
         self.message_post(body='Actividad finalizada. Removida del catálogo automáticamente.')
 
     def action_firmar_constancias(self):
@@ -349,16 +551,18 @@ class Actividad(models.Model):
             raise ValidationError('Solo se pueden firmar constancias de actividades finalizadas.')
         if self.jd_firmo:
             raise ValidationError('El Jefe de Departamento ya firmó las constancias de esta actividad.')
-        self.write({'jd_firmo': True})
+        # La firma es una acción de negocio válida sobre una actividad finalizada
+        self.with_context(bypass_edit_protection=True).write({'jd_firmo': True})
         if self.constancias_firmadas:
             self.message_post(
-                body='Constancias firmadas por el Jefe de Departamento.' +
-                'Ambas firmas completas — constancias liberadas a expedientes.'
-                )
+                body='Constancias firmadas por el Jefe de Departamento. '
+                     'Ambas firmas completas — constancias liberadas a expedientes.'
+            )
         else:
             self.message_post(
-                body='Constancias firmadas por el Jefe de Departamento. Pendiente firma del Responsable de Actividad.'
-                )
+                body='Constancias firmadas por el Jefe de Departamento. '
+                     'Pendiente firma del Responsable de Actividad.'
+            )
 
     def _actualizar_estado_por_fecha(self):
         """Cron: actualiza estados según fechas."""
@@ -371,14 +575,19 @@ class Actividad(models.Model):
                 ('estado_code', '=', 'pendiente_inicio'),
                 ('fecha_inicio', '<=', hoy),
             ])
-            pendientes.write({'estado_id': estado_en_curso.id})
+            pendientes.with_context(bypass_edit_protection=True).write(
+                {'estado_id': estado_en_curso.id}
+            )
 
         if estado_finalizada:
             en_curso = self.search([
                 ('estado_code', '=', 'en_curso'),
                 ('fecha_fin', '<=', hoy),
             ])
-            en_curso.write({'estado_id': estado_finalizada.id, 'en_catalogo': False})
+            en_curso.with_context(bypass_edit_protection=True).write({
+                'estado_id': estado_finalizada.id,
+                'en_catalogo': False,
+            })
 
 
 class ActividadDepartamento(models.Model):

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -565,6 +565,26 @@ class Actividad(models.Model):
                      'Pendiente firma del Responsable de Actividad.'
             )
 
+    def action_firmar_constancias_responsable(self):
+        """El Responsable de Actividad firma su parte. Las constancias solo se liberan cuando ambos firmen."""
+        self.ensure_one()
+        if self.estado_code != 'finalizada':
+            raise ValidationError('Solo se pueden firmar constancias de actividades finalizadas.')
+        if self.responsable_firmo:
+            raise ValidationError('El Responsable de Actividad ya firmó las constancias de esta actividad.')
+        # La firma es una acción de negocio válida sobre una actividad finalizada
+        self.with_context(bypass_edit_protection=True).write({'responsable_firmo': True})
+        if self.constancias_firmadas:
+            self.message_post(
+                body='Constancias firmadas por el Responsable de Actividad. '
+                     'Ambas firmas completas — constancias liberadas a expedientes.'
+            )
+        else:
+            self.message_post(
+                body='Constancias firmadas por el Responsable de Actividad. '
+                     'Pendiente firma del Jefe de Departamento.'
+            )
+
     def _actualizar_estado_por_fecha(self):
         """Cron: actualiza estados según fechas."""
         hoy = date.today()

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -161,7 +161,7 @@ class Actividad(models.Model):
     permisos_actividad_pendiente_inicio = fields.Boolean(
         string='Solo Responsable, Fechas y Horas Editables',
         compute='_compute_permisos_edicion',
-        help='True cuando el JD solo puede modificar los campos Responsable de Actividad, Fecha de Inicio, ' \
+        help='True cuando el JD solo puede modificar los campos Responsable de Actividad, Fecha de Inicio, '
         'Fecha de Finalización y Horario por Día.',
     )
     permisos_actividad_en_curso = fields.Boolean(
@@ -396,7 +396,7 @@ class Actividad(models.Model):
                       'por el Comité Académico. No puede modificarla durante la revisión.')
                     % rec.name
                 )
-                        
+            
             # ── Regla 3: En catálogo / Pendiente de Inicio ──
             if rec.en_catalogo or rec.estado_code in ('aprobada', 'pendiente_inicio'):
                 campos_permitidos = {'responsable_actividad_id', 'fecha_inicio', 'fecha_fin', 'horario'}

--- a/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
@@ -99,6 +99,8 @@ class PropuestaActividadComplementaria(models.Model):
 
     # ────────────────────────────────────────────────────────────────────────
     # Business logic
+    # Usamos bypass_edit_protection=True porque estas acciones escriben
+    # campos auto-gestionados (estado_id) en la actividad asociada.
     # ────────────────────────────────────────────────────────────────────────
 
     def action_aprobar(self):
@@ -106,7 +108,9 @@ class PropuestaActividadComplementaria(models.Model):
         estado_aprobada = self.env.ref('actividades_complementarias.estado_solicitud_aprobada')
         estado_act_aprobada = self.env.ref('actividades_complementarias.estado_aprobada')
         self.write({'estado_solicitud_id': estado_aprobada.id})
-        self.actividad_id.write({'estado_id': estado_act_aprobada.id})
+        self.actividad_id.with_context(bypass_edit_protection=True).write(
+            {'estado_id': estado_act_aprobada.id}
+        )
         self.message_post(body='Propuesta aprobada por el Comité Académico.')
 
     def action_rechazar(self):
@@ -116,7 +120,9 @@ class PropuestaActividadComplementaria(models.Model):
         estado_rechazada = self.env.ref('actividades_complementarias.estado_solicitud_rechazada')
         estado_act_rechazada = self.env.ref('actividades_complementarias.estado_rechazada')
         self.write({'estado_solicitud_id': estado_rechazada.id})
-        self.actividad_id.write({'estado_id': estado_act_rechazada.id})
+        self.actividad_id.with_context(bypass_edit_protection=True).write(
+            {'estado_id': estado_act_rechazada.id}
+        )
         self.message_post(body=f'Propuesta rechazada. Motivo: {self.motivo_rechazo}')
 
     def action_abrir_wizard_rechazo(self):

--- a/odoo/addons/actividades_complementarias/security/actividades_security.xml
+++ b/odoo/addons/actividades_complementarias/security/actividades_security.xml
@@ -70,14 +70,28 @@
     </record>
 
     <!-- ════════════════════════════════════════════════════════════════════
-         Record rules
-         Alumno     — solo ve actividades en catálogo (en_catalogo = True).
-         Responsable — solo ve actividades donde está asignado como responsable.
-         JD y Comité — el filtrado por departamento se gestiona en Python
-                       (_search override); no requieren record rules adicionales
-                       a menos que se necesite aislamiento multi-empresa.
+         Record Rules
+         ════════════════════════════════════════════════════════════════════
+
+         Alumno
+           Solo ve actividades en catálogo (en_catalogo = True).
+
+         Responsable de Actividad
+           Solo ve actividades donde está asignado como responsable.
+
+         Jefe de Departamento
+           Puede ver (lectura):
+             - Sus propias actividades (jefe_departamento_id = usuario).
+             - Actividades en catálogo de cualquier departamento.
+           No puede ver (ni acceder) actividades de otros JD fuera del catálogo.
+           Las restricciones de escritura se aplican adicionalmente en
+           Actividad.write() según el estado del registro.
+
+         Admin y Comité
+           Sin record rules adicionales; ven todo.
     ════════════════════════════════════════════════════════════════════ -->
 
+    <!-- Alumno: solo actividades en catálogo -->
     <record id="rule_actividad_alumno" model="ir.rule">
         <field name="name">Alumno: solo actividades en catálogo</field>
         <field name="model_id" ref="model_actividad_complementaria"/>
@@ -89,6 +103,7 @@
         <field name="perm_unlink" eval="False"/>
     </record>
 
+    <!-- Responsable de Actividad: solo sus actividades asignadas -->
     <record id="rule_actividad_responsable" model="ir.rule">
         <field name="name">Responsable: solo sus actividades asignadas</field>
         <field name="model_id" ref="model_actividad_complementaria"/>
@@ -98,6 +113,29 @@
         <field name="perm_write" eval="True"/>
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <!--
+        Jefe de Departamento:
+          - Lee y escribe sus propias actividades (todas).
+          - Lee (solo lectura ORM) actividades de otros JD que estén en catálogo.
+        NOTA: perm_write=True aquí no implica que pueda escribir todo;
+        Actividad.write() aplica las restricciones por estado encima de esta regla.
+    -->
+    <record id="rule_actividad_jefe_departamento" model="ir.rule">
+        <field name="name">JD: sus actividades y actividades en catálogo</field>
+        <field name="model_id" ref="model_actividad_complementaria"/>
+        <field name="domain_force">
+            ['|',
+                ('jefe_departamento_id', '=', user.id),
+                ('en_catalogo', '=', True)
+            ]
+        </field>
+        <field name="groups" eval="[(4, ref('actividades_complementarias.group_jefe_departamento'))]"/>
+        <field name="perm_read"   eval="True"/>
+        <field name="perm_write"  eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
     </record>
 
 </odoo>

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -160,7 +160,7 @@ class TestActividad(TransactionCase):
         self.assertFalse(actividad.responsable_firmo)
         self.assertFalse(actividad.constancias_firmadas)
         # Responsable firma también
-        actividad.write({'responsable_firmo': True})
+        actividad.action_firmar_constancias_responsable()
         self.assertTrue(actividad.constancias_firmadas)
 
     def test_jd_no_puede_firmar_dos_veces(self):

--- a/odoo/addons/actividades_complementarias/views/actividad_views.xml
+++ b/odoo/addons/actividades_complementarias/views/actividad_views.xml
@@ -48,6 +48,20 @@
     </record>
 
     <!-- ── Form ─────────────────────────────────────────────────────────── -->
+    <!--
+        Lógica de solo-lectura del formulario:
+
+        Los campos computed 'permisos_actividad_finalizada' y 'permisos_actividad_en_curso'
+        son calculados en Python por _compute_permisos_edicion() según el
+        estado del registro y el rol del usuario en sesión.
+
+        - permisos_actividad_finalizada=True          → todos los campos son readonly.
+        - permisos_actividad_en_curso=True → solo 'responsable_actividad_id' es editable;
+                                           el resto son readonly.
+        - Ambos False                 → edición normal (según estado y rol).
+
+        La protección a nivel de ORM se aplica en Actividad.write().
+    -->
     <record id="view_actividad_form" model="ir.ui.view">
         <field name="name">actividad.complementaria.form</field>
         <field name="model">actividad.complementaria</field>
@@ -87,50 +101,100 @@
                             groups="actividades_complementarias.group_jefe_departamento,actividades_complementarias.group_admin_actividades"/>
                 </header>
                 <sheet>
+                    <!-- Flags internos (no visibles al usuario) -->
                     <field name="tiene_propuesta_activa" invisible="1"/>
                     <field name="tipo_actividad_predefinida" invisible="1"/>
                     <field name="tipo_es_nueva" invisible="1"/>
                     <field name="dominio_responsable" invisible="1"/>
                     <field name="dominio_alumnos" invisible="1"/>
-                    <field name="ruta_imagen" widget="image" class="oe_avatar"/>
+                    <!-- Flags de permisos de edición (calculados por rol y estado) -->
+                    <field name="permisos_actividad_finalizada" invisible="1"/>
+                    <field name="permisos_actividad_en_curso" invisible="1"/>
+
+                    <!--
+                        Banner informativo de solo lectura.
+                        Aparece cuando el formulario está bloqueado para el usuario actual.
+                    -->
+                    <div class="alert alert-warning mb-2"
+                         invisible="not permisos_actividad_finalizada and not permisos_actividad_pendiente_inicio 
+                         and not permisos_actividad_en_curso"
+                         role="alert">
+                        <span invisible="estado_code == 'finalizada'">
+                            <i class="fa fa-lock me-1"/>
+                            <b invisible="permisos_actividad_en_curso">
+                                Esta actividad no puede modificarse en su estado actual.
+                            </b>
+                            <b invisible="not permisos_actividad_pendiente_inicio">
+                                Solo puede modificar los campos <i>Responsable de Actividad</i>, <i>Fecha de Inicio</i>, <i>Fecha de Finalización</i>, y 
+                                <i>Horario por Día</i> en este estado.
+                            </b>
+                            <b invisible="not permisos_actividad_en_curso">
+                                Solo puede modificar el campo <i>Responsable de Actividad</i> en este estado. Probando cambio de texto
+                            </b>
+                        </span>
+                        <span invisible="estado_code != 'finalizada'">
+                            <i class="fa fa-lock me-1"/>
+                            <b>Esta actividad está finalizada y no puede ser modificada.</b>
+                        </span>
+                    </div>
+
+                    <field name="ruta_imagen" widget="image" class="oe_avatar"
+                           readonly="permisos_actividad_finalizada or permisos_actividad_en_curso"/>
                     <div class="oe_title">
-                        <h1><field name="name" placeholder="Nombre de la actividad..."/></h1>
+                        <h1>
+                            <field name="name" placeholder="Nombre de la actividad..."
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_en_curso"/>
+                        </h1>
                     </div>
                     <group>
                         <group string="Información General">
-                            <field name="tipo_actividad_id"/>
+                            <field name="tipo_actividad_id"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
                             <field name="actividad_predefinida"
                                    invisible="tipo_es_nueva"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"
                                    help="Seleccione si la actividad es predefinida (aprobación automática). Deje en blanco para quitar la selección."/>
-                            <field name="periodo"/>
+                            <field name="periodo"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
+                            <!-- jefe_departamento_id y departamento_id son siempre readonly -->
                             <field name="jefe_departamento_id" readonly="1"/>
                             <field name="departamento_id" readonly="1"/>
                             <field name="responsable_actividad_id"
                                    domain="dominio_responsable"
+                                   readonly="permisos_actividad_finalizada"
                                    options="{'no_create': True, 'no_quick_create': True}"/>
                         </group>
                         <group string="Fechas y Duración">
-                            <field name="fecha_inicio"/>
-                            <field name="fecha_fin"/>
-                            <field name="cantidad_horas"/>
-                            <field name="creditos"/>
-                            <field name="horario" placeholder="Ej: Lunes 10:00-12:00, Miércoles 10:00-12:00"/>
+                            <field name="fecha_inicio"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_en_curso"/>
+                            <field name="fecha_fin"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_en_curso"/>
+                            <field name="cantidad_horas"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
+                            <field name="creditos"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
+                            <field name="horario"
+                                   placeholder="Ej: Lunes 10:00-12:00, Miércoles 10:00-12:00"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_en_curso"/>
                         </group>
                     </group>
-                    <group string="Cupos">
-                        <field name="cupo_ilimitado"/>
-                        <field name="cupo_min" invisible="cupo_ilimitado"/>
-                        <field name="cupo_max" invisible="cupo_ilimitado"/>
+                    <group string="Cupos"
+                           readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso">
+                        <field name="cupo_ilimitado" readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
+                        <field name="cupo_min" invisible="cupo_ilimitado" readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
+                        <field name="cupo_max" invisible="cupo_ilimitado" readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
                     </group>
                     <group string="Descripción">
                         <field name="descripcion" nolabel="1" colspan="2"
-                               placeholder="Descripción de la actividad (máximo 2000 caracteres)..."/>
+                               placeholder="Descripción de la actividad (máximo 2000 caracteres)..."
+                               readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"/>
                     </group>
                     <notebook>
                         <page string="Alumnos Asignados" name="alumnos"
                               invisible="estado_code in ['aprobada','rechazada'] or en_catalogo">
                             <field name="alumno_ids"
                                    domain="dominio_alumnos"
+                                   readonly="permisos_actividad_finalizada or permisos_actividad_pendiente_inicio or permisos_actividad_en_curso"
                                    options="{'no_create': True, 'no_quick_create': True}">
                                 <list>
                                     <field name="name"/>

--- a/odoo/addons/actividades_complementarias/wizards/wizard_aprobar_propuesta.py
+++ b/odoo/addons/actividades_complementarias/wizards/wizard_aprobar_propuesta.py
@@ -11,11 +11,11 @@ class WizardAprobarPropuesta(models.TransientModel):
     propuesta_id = fields.Many2one('actividad.propuesta', string='Propuesta', required=True)
     nombre_actividad = fields.Char(string='Actividad', readonly=True)
     creditos = fields.Selection([
-        ('0.5', '0.5 creditos'),
-        ('1.0', '1 credito'),
-        ('1.5', '1.5 creditos'),
-        ('2.0', '2 creditos'),
-    ], string='Creditos Asignados', required=True)
+        ('0.5', '0.5 créditos'),
+        ('1.0', '1 crédito'),
+        ('1.5', '1.5 créditos'),
+        ('2.0', '2 créditos'),
+    ], string='Créditos Asignados', required=True)
 
     @api.model
     def default_get(self, fields_list):
@@ -30,6 +30,9 @@ class WizardAprobarPropuesta(models.TransientModel):
         self.ensure_one()
         if not self.creditos:
             raise ValidationError('Debe asignar los creditos a la actividad.')
-        self.propuesta_id.actividad_id.write({'creditos': self.creditos})
+        # bypass_edit_protection: el Comité asigna créditos como acción de negocio
+        self.propuesta_id.actividad_id.with_context(bypass_edit_protection=True).write(
+            {'creditos': self.creditos}
+        )
         self.propuesta_id.action_aprobar()
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
feat: Limitar campos modificables por el Jefe de Departamento durante los estados distintos estados de una actividad complementaria Fixes #31

## Descripción

Cada estado del ciclo de vida de una actividad complementaria aplica distintas restricciones sobre lo que el Jefe de Departamento propietario de la actividad puede modificar. Esto ahora se ve reflejado en el sistema

## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [x] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [x] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [x] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [x] Grupos nuevos están declarados en `security/actividades_security.xml`
- [x] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [x] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [x] Linting sin errores (`flake8 --max-line-length=120`)
- [x] No hay `print()`, TODOs ni código comentado en el diff
- [x] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [x] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [x] Si se añade dependencia Python, está en `requirements.txt`

## Cómo probar

Usar el usuario `jefe.sistemas@ittech.edu.mx`, contraseña `Admin1234!`. Comprobar la modificación de actividades en diferentes estados usando la información de prueba
