### PR TITLE
JaredReyes107/issue42

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -1,7 +1,28 @@
 # -*- coding: utf-8 -*-
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError, UserError
-from datetime import date
+from datetime import date, timedelta
+
+
+def _n_dias_habiles(n, desde=None):
+    """Avanza *n* días hábiles (excluyendo domingos) desde *desde*.
+
+    Args:
+        n:     Número de días hábiles a avanzar.
+        desde: Fecha base. Si es None se usa la fecha actual.
+    Returns:
+        date con la fecha resultante.
+    """
+    base = desde if desde is not None else date.today()
+    contados = 0
+    candidato = base
+    while contados < n:
+        candidato += timedelta(days=1)
+        if candidato.weekday() != 6:   # 6 = domingo
+            contados += 1
+    return candidato
+
+
 
 
 class Actividad(models.Model):
@@ -431,39 +452,54 @@ class Actividad(models.Model):
     # Constraints
     # ────────────────────────────────────────────────────────────────────────
 
-    @staticmethod
-    def _fecha_minima_inicio():
-        """Devuelve la fecha mínima válida para fecha_inicio.
-
-        Cuenta 5 días hábiles hacia adelante desde hoy, excluyendo domingos.
-        """
-        from datetime import timedelta as td
-        candidato = date.today()
-        contados = 0
-        while contados < 5:
-            candidato += td(days=1)
-            if candidato.weekday() != 6:   # 6 = domingo
-                contados += 1
-        return candidato
-
     @api.constrains('fecha_inicio', 'fecha_fin')
     def _check_fechas(self):
         bypass = (
             self.env.context.get('install_demo')
             or self.env.context.get('skip_fecha_check')
         )
+        manana = date.today() + timedelta(days=1)
         for rec in self:
             if rec.fecha_inicio and not bypass:
-                min_fecha = self._fecha_minima_inicio()
-                if rec.fecha_inicio < min_fecha:
-                    raise ValidationError(
-                        _(
-                            'La fecha de inicio debe ser al menos 5 días hábiles '
-                            '(sin domingos) a partir de hoy. '
-                            'La fecha mínima válida es %(fecha)s.',
-                            fecha=min_fecha.strftime('%d/%m/%Y'),
+                es_nuevo = not rec._origin.id   # True en create, False en write
+                if es_nuevo:
+                    # Al crear: mínimo 5 días hábiles desde hoy
+                    min_fecha = _n_dias_habiles(5)
+                    if rec.fecha_inicio < min_fecha:
+                        raise ValidationError(
+                            _(
+                                'La fecha de inicio debe ser al menos 5 días hábiles '
+                                '(sin domingos) a partir de hoy. '
+                                'La fecha mínima válida es %(fecha)s.',
+                                fecha=min_fecha.strftime('%d/%m/%Y'),
+                            )
                         )
+                else:
+                    # En edición: si existe propuesta aprobada, el mínimo se calcula
+                    # como 5 días hábiles contados desde la fecha de envío de esa propuesta,
+                    # de modo que el tiempo total (envío → inicio) sea al menos 5 días hábiles.
+                    # Piso absoluto: siempre al menos mañana.
+                    propuesta = self.env['actividad.propuesta'].search(
+                        [
+                            ('actividad_id', '=', rec.id),
+                            ('estado_code', '=', 'aprobada'),
+                        ],
+                        order='fecha desc',
+                        limit=1,
                     )
+                    if propuesta:
+                        min_desde_propuesta = _n_dias_habiles(5, desde=propuesta.fecha)
+                        min_fecha = max(min_desde_propuesta, manana)
+                    else:
+                        min_fecha = manana
+
+                    if rec.fecha_inicio < min_fecha:
+                        raise ValidationError(
+                            _(
+                                'La fecha de inicio no puede ser anterior a %(fecha)s.',
+                                fecha=min_fecha.strftime('%d/%m/%Y'),
+                            )
+                        )
             if rec.fecha_fin and rec.fecha_inicio and rec.fecha_fin <= rec.fecha_inicio:
                 raise ValidationError('La fecha de fin debe ser posterior a la fecha de inicio.')
 

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -22,9 +22,6 @@ def _n_dias_habiles(n, desde=None):
             contados += 1
     return candidato
 
-
-
-
 class Actividad(models.Model):
     _name = 'actividad.complementaria'
     _description = 'Actividad Complementaria'

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 
 
 def _n_dias_habiles(n, desde=None):
-    """Avanza *n* días hábiles (excluyendo domingos) desde *desde*.
+    """Avanza *n* días hábiles (lunes a viernes) desde *desde*.
 
     Args:
         n:     Número de días hábiles a avanzar.
@@ -18,7 +18,7 @@ def _n_dias_habiles(n, desde=None):
     candidato = base
     while contados < n:
         candidato += timedelta(days=1)
-        if candidato.weekday() != 6:   # 6 = domingo
+        if candidato.weekday() < 5:   # 0=lun … 4=vie; 5=sáb, 6=dom
             contados += 1
     return candidato
 
@@ -353,6 +353,23 @@ class Actividad(models.Model):
                 rec.permisos_actividad_en_curso = False
 
     # ────────────────────────────────────────────────────────────────────────
+    # ORM override: create()
+    # ────────────────────────────────────────────────────────────────────────
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Estampa el flag actividad_creating=True en el contexto para que
+        _check_fechas pueda distinguir una creación de una edición.
+
+        _origin.id no es fiable aquí porque el constraint corre después de que
+        el registro ya fue insertado en la BD y _origin ya tiene un ID real.
+        """
+        return super(
+            Actividad,
+            self.with_context(actividad_creating=True),
+        ).create(vals_list)
+
+    # ────────────────────────────────────────────────────────────────────────
     # ORM override: write()
     # ────────────────────────────────────────────────────────────────────────
 
@@ -461,7 +478,9 @@ class Actividad(models.Model):
         manana = date.today() + timedelta(days=1)
         for rec in self:
             if rec.fecha_inicio and not bypass:
-                es_nuevo = not rec._origin.id   # True en create, False en write
+                # True durante create() gracias al flag que estampa el override;
+                # False durante write() donde el flag no está presente.
+                es_nuevo = self.env.context.get('actividad_creating', False)
                 if es_nuevo:
                     # Al crear: mínimo 5 días hábiles desde hoy
                     min_fecha = _n_dias_habiles(5)

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -234,7 +234,6 @@ class Actividad(models.Model):
             if depto:
                 rec.departamento_id = depto
             else:
-                # Fallback: buscar en el registro de permisos del empleado
                 emp = self.env['actividad.empleado.permiso'].search(
                     [('user_id', '=', rec.jefe_departamento_id.id)], limit=1
                 )
@@ -432,13 +431,39 @@ class Actividad(models.Model):
     # Constraints
     # ────────────────────────────────────────────────────────────────────────
 
+    @staticmethod
+    def _fecha_minima_inicio():
+        """Devuelve la fecha mínima válida para fecha_inicio.
+
+        Cuenta 5 días hábiles hacia adelante desde hoy, excluyendo domingos.
+        """
+        from datetime import timedelta as td
+        candidato = date.today()
+        contados = 0
+        while contados < 5:
+            candidato += td(days=1)
+            if candidato.weekday() != 6:   # 6 = domingo
+                contados += 1
+        return candidato
+
     @api.constrains('fecha_inicio', 'fecha_fin')
     def _check_fechas(self):
+        bypass = (
+            self.env.context.get('install_demo')
+            or self.env.context.get('skip_fecha_check')
+        )
         for rec in self:
-            # No validar fechas pasadas cuando se cargan datos de demo o desde el sistema
-            if not self.env.context.get('install_demo') and not self.env.context.get('skip_fecha_check'):
-                if rec.fecha_inicio and rec.fecha_inicio < date.today():
-                    raise ValidationError('La fecha de inicio no puede ser anterior a hoy.')
+            if rec.fecha_inicio and not bypass:
+                min_fecha = self._fecha_minima_inicio()
+                if rec.fecha_inicio < min_fecha:
+                    raise ValidationError(
+                        _(
+                            'La fecha de inicio debe ser al menos 5 días hábiles '
+                            '(sin domingos) a partir de hoy. '
+                            'La fecha mínima válida es %(fecha)s.',
+                            fecha=min_fecha.strftime('%d/%m/%Y'),
+                        )
+                    )
             if rec.fecha_fin and rec.fecha_inicio and rec.fecha_fin <= rec.fecha_inicio:
                 raise ValidationError('La fecha de fin debe ser posterior a la fecha de inicio.')
 
@@ -479,7 +504,6 @@ class Actividad(models.Model):
                 'Esta actividad ya fue aprobada o está en curso/finalizada. '
                 'No puede ser reenviada al Comité Académico.'
             )
-        # Verificar que no haya propuesta pendiente o aprobada ya
         propuesta_existente = self.env['actividad.propuesta'].search([
             ('actividad_id', '=', self.id),
             ('estado_code', 'in', ('en_revision', 'aprobada')),
@@ -497,7 +521,6 @@ class Actividad(models.Model):
             body='Propuesta enviada al Comité Académico para su revisión. '
                  'Se aprobará automáticamente si no hay respuesta en 5 días.'
         )
-        # Abrir la lista de propuestas
         return {
             'type': 'ir.actions.act_window',
             'name': 'Mis Propuestas al Comité',
@@ -508,9 +531,7 @@ class Actividad(models.Model):
         }
 
     def action_enviar_catalogo(self):
-        """Envía la actividad al catálogo.
-        Si tiene actividad_predefinida, se aprueba automáticamente antes de enviar.
-        """
+        """Envía la actividad al catálogo."""
         self.ensure_one()
         if self.estado_code == 'rechazada':
             raise ValidationError(

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -359,13 +359,14 @@ class Actividad(models.Model):
         """Estampa el flag actividad_creating=True en el contexto para que
         _check_fechas pueda distinguir una creación de una edición.
 
-        _origin.id no es fiable aquí porque el constraint corre después de que
-        el registro ya fue insertado en la BD y _origin ya tiene un ID real.
+        El flag se elimina del recordset devuelto para que llamadas
+        posteriores a write() sobre esos registros no lo hereden.
         """
-        return super(
+        records = super(
             Actividad,
             self.with_context(actividad_creating=True),
         ).create(vals_list)
+        return records.with_context(actividad_creating=False)
 
     # ────────────────────────────────────────────────────────────────────────
     # ORM override: write()

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -22,6 +22,7 @@ def _n_dias_habiles(n, desde=None):
             contados += 1
     return candidato
 
+
 class Actividad(models.Model):
     _name = 'actividad.complementaria'
     _description = 'Actividad Complementaria'

--- a/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
@@ -25,7 +25,7 @@ class PropuestaActividadComplementaria(models.Model):
     )
     fecha = fields.Date(
         string='Fecha de Envío',
-        default=fields.Date.today,
+        default=lambda self: fields.Date.context_today(self),
         readonly=True,
     )
     fecha_limite_revision = fields.Date(

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -25,6 +25,7 @@ def _n_dias_habiles(n, desde=None):
             contados += 1
     return candidato
 
+
 class TestActividad(TransactionCase):
     """Tests para el modelo actividad.complementaria.
 
@@ -48,7 +49,7 @@ class TestActividad(TransactionCase):
         # tipo_actividad no tiene XMLs de datos predefinidos — se crea aquí
         cls.tipo = cls.env['actividad.tipo'].create({'name': 'Conferencia Test'})
 
-        cls.fecha_valida    = _n_dias_habiles(5)   # mínimo exacto exigido por el constraint
+        cls.fecha_valida = _n_dias_habiles(5)   # mínimo exacto exigido por el constraint
         cls.fecha_fin_valida = _n_dias_habiles(6)   # un día hábil más, para que fin > inicio
 
     def _make_actividad(self, **kwargs):

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -2,7 +2,6 @@
 from datetime import date, timedelta
 
 from odoo.exceptions import ValidationError
-from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -116,6 +116,61 @@ class TestActividad(TransactionCase):
         with self.assertRaises(ValidationError):
             self._make_actividad(fecha_inicio=self.fecha_valida, fecha_fin=self.fecha_valida)
 
+    def test_edicion_sin_propuesta_manana_ok(self):
+        """En edición sin propuesta aprobada, mover fecha_inicio a mañana es válido."""
+        actividad = self._make_actividad()
+        manana = date.today() + timedelta(days=1)
+        actividad.write({
+            'fecha_inicio': manana,
+            'fecha_fin': manana + timedelta(days=1),
+        })
+        self.assertEqual(actividad.fecha_inicio, manana)
+
+    def test_edicion_sin_propuesta_hoy_falla(self):
+        """En edición sin propuesta aprobada, fecha_inicio = hoy debe fallar."""
+        actividad = self._make_actividad()
+        with self.assertRaises(ValidationError):
+            actividad.write({'fecha_inicio': date.today()})
+
+    def test_edicion_con_propuesta_usa_fecha_envio(self):
+        """Con propuesta aprobada, el mínimo de fecha_inicio se calcula desde la fecha de envío."""
+        # Crear la actividad sorteando el constraint (usamos fechas futuras válidas)
+        actividad = self._make_actividad()
+
+        # Simular una propuesta cuya fecha de envío fue hace un día hábil:
+        # buscamos el día hábil más reciente anterior a hoy.
+        fecha_envio = date.today() - timedelta(days=1)
+        while fecha_envio.weekday() == 6:   # retroceder si cae en domingo
+            fecha_envio -= timedelta(days=1)
+
+        estado_en_revision = self.env.ref(
+            'actividades_complementarias.estado_solicitud_en_revision'
+        )
+        estado_aprobada = self.env.ref(
+            'actividades_complementarias.estado_solicitud_aprobada'
+        )
+        propuesta = self.env['actividad.propuesta'].create({
+            'actividad_id': actividad.id,
+            'estado_solicitud_id': estado_en_revision.id,
+            'fecha': fecha_envio,
+        })
+        propuesta.write({'estado_solicitud_id': estado_aprobada.id})
+
+        # La fecha mínima válida es 5 días hábiles desde fecha_envio, pero
+        # nunca antes de mañana.
+        min_fecha = max(_n_dias_habiles(5, desde=fecha_envio), date.today() + timedelta(days=1))
+
+        # Un día antes del mínimo debe fallar
+        with self.assertRaises(ValidationError):
+            actividad.write({'fecha_inicio': min_fecha - timedelta(days=1)})
+
+        # El día exacto del mínimo debe funcionar
+        actividad.write({
+            'fecha_inicio': min_fecha,
+            'fecha_fin': min_fecha + timedelta(days=1),
+        })
+        self.assertEqual(actividad.fecha_inicio, min_fecha)
+
     # ── Constraints de cupos ─────────────────────────────────────────────────
 
     def test_cupo_min_cero_falla(self):

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -11,7 +11,7 @@ from odoo.tests.common import TransactionCase
 # ---------------------------------------------------------------------------
 
 def _n_dias_habiles(n, desde=None):
-    """Devuelve la fecha resultante de avanzar *n* días hábiles (sin domingos).
+    """Devuelve la fecha resultante de avanzar *n* días hábiles (lunes a viernes).
 
     Args:
         n:     Número de días hábiles a avanzar.
@@ -22,7 +22,7 @@ def _n_dias_habiles(n, desde=None):
     candidato = base
     while contados < n:
         candidato += timedelta(days=1)
-        if candidato.weekday() != 6:   # 6 = domingo
+        if candidato.weekday() < 5:   # 0=lun … 4=vie; 5=sáb, 6=dom
             contados += 1
     return candidato
 
@@ -138,9 +138,9 @@ class TestActividad(TransactionCase):
         actividad = self._make_actividad()
 
         # Simular una propuesta cuya fecha de envío fue hace un día hábil:
-        # buscamos el día hábil más reciente anterior a hoy.
+        # buscamos el día hábil (lun-vie) más reciente anterior a hoy.
         fecha_envio = date.today() - timedelta(days=1)
-        while fecha_envio.weekday() == 6:   # retroceder si cae en domingo
+        while fecha_envio.weekday() >= 5:   # retroceder si cae en sáb(5) o dom(6)
             fecha_envio -= timedelta(days=1)
 
         estado_en_revision = self.env.ref(

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -6,7 +6,28 @@ from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
-@tagged('actividades_complementarias', '-standard')
+# ---------------------------------------------------------------------------
+# Utilidad de fechas compartida entre tests
+# ---------------------------------------------------------------------------
+
+def _n_dias_habiles(n, desde=None):
+    """Devuelve la fecha resultante de avanzar *n* días hábiles (sin domingos).
+
+    Args:
+        n:     Número de días hábiles a avanzar.
+        desde: Fecha base. Si es None se usa la fecha actual.
+    """
+    base = desde or date.today()
+    contados = 0
+    candidato = base
+    while contados < n:
+        candidato += timedelta(days=1)
+        if candidato.weekday() != 6:   # 6 = domingo
+            contados += 1
+    return candidato
+
+
+
 class TestActividad(TransactionCase):
     """Tests para el modelo actividad.complementaria.
 
@@ -30,8 +51,8 @@ class TestActividad(TransactionCase):
         # tipo_actividad no tiene XMLs de datos predefinidos — se crea aquí
         cls.tipo = cls.env['actividad.tipo'].create({'name': 'Conferencia Test'})
 
-        cls.manana = date.today() + timedelta(days=1)
-        cls.pasado_manana = date.today() + timedelta(days=2)
+        cls.fecha_valida    = _n_dias_habiles(5)   # mínimo exacto exigido por el constraint
+        cls.fecha_fin_valida = _n_dias_habiles(6)   # un día hábil más, para que fin > inicio
 
     def _make_actividad(self, **kwargs):
         """Helper: crea una actividad con valores mínimos válidos.
@@ -43,8 +64,8 @@ class TestActividad(TransactionCase):
             'name': 'Actividad de prueba',
             'tipo_actividad_id': self.tipo.id,
             'periodo': self.periodo.id,   # Many2one: pasar el ID del registro
-            'fecha_inicio': self.manana,
-            'fecha_fin': self.pasado_manana,
+            'fecha_inicio': self.fecha_valida,
+            'fecha_fin': self.fecha_fin_valida,
             'cantidad_horas': 8.0,
             'cupo_min': 5,
             'cupo_max': 30,
@@ -57,7 +78,6 @@ class TestActividad(TransactionCase):
     def test_fecha_inicio_pasada_falla(self):
         """No se debe poder crear una actividad con fecha de inicio en el pasado."""
         with self.assertRaises(ValidationError):
-            # Sin skip_fecha_check, el constraint de fecha debe activarse
             self.env['actividad.complementaria'].create({
                 'name': 'Actividad pasada',
                 'tipo_actividad_id': self.tipo.id,
@@ -67,10 +87,34 @@ class TestActividad(TransactionCase):
                 'cantidad_horas': 4.0,
             })
 
+    def test_fecha_inicio_menos_de_5_habiles_falla(self):
+        """Una fecha de inicio con solo 4 días hábiles de antelación debe fallar."""
+        with self.assertRaises(ValidationError):
+            self.env['actividad.complementaria'].create({
+                'name': 'Actividad con poco margen',
+                'tipo_actividad_id': self.tipo.id,
+                'periodo': self.periodo.id,
+                'fecha_inicio': _n_dias_habiles(4),
+                'fecha_fin': _n_dias_habiles(5),
+                'cantidad_horas': 4.0,
+            })
+
+    def test_fecha_inicio_exactamente_5_habiles_ok(self):
+        """Una fecha de inicio con exactamente 5 días hábiles de antelación debe ser válida."""
+        actividad = self.env['actividad.complementaria'].create({
+            'name': 'Actividad con margen justo',
+            'tipo_actividad_id': self.tipo.id,
+            'periodo': self.periodo.id,
+            'fecha_inicio': _n_dias_habiles(5),
+            'fecha_fin': _n_dias_habiles(6),
+            'cantidad_horas': 4.0,
+        })
+        self.assertTrue(actividad.id)
+
     def test_fecha_fin_antes_de_inicio_falla(self):
         """La fecha de fin debe ser posterior a la fecha de inicio."""
         with self.assertRaises(ValidationError):
-            self._make_actividad(fecha_inicio=self.manana, fecha_fin=self.manana)
+            self._make_actividad(fecha_inicio=self.fecha_valida, fecha_fin=self.fecha_valida)
 
     # ── Constraints de cupos ─────────────────────────────────────────────────
 

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -60,7 +60,7 @@ class TestActividad(TransactionCase):
         vals = {
             'name': 'Actividad de prueba',
             'tipo_actividad_id': self.tipo.id,
-            'periodo': self.periodo.id,   # Many2one: pasar el ID del registro
+            'periodo': self.periodo.id,
             'fecha_inicio': self.fecha_valida,
             'fecha_fin': self.fecha_fin_valida,
             'cantidad_horas': 8.0,

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -26,8 +26,6 @@ def _n_dias_habiles(n, desde=None):
             contados += 1
     return candidato
 
-
-
 class TestActividad(TransactionCase):
     """Tests para el modelo actividad.complementaria.
 

--- a/odoo/addons/actividades_complementarias/tests/test_propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_propuesta_actividad.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import date, timedelta
 
+from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
@@ -66,7 +67,10 @@ class TestPropuestaActividad(TransactionCase):
         propuesta = self._make_propuesta()
         self.assertEqual(propuesta.encabezado, self.actividad.name)
 
-    def test_fecha_limite_es_cinco_dias_despues(self):
+    def test_fecha_envio_es_hoy(self):
+        """La fecha de envío de la propuesta debe ser la fecha actual en la zona horaria del usuario."""
+        propuesta = self._make_propuesta()
+        self.assertEqual(propuesta.fecha, fields.Date.context_today(propuesta))
         """La fecha límite de revisión debe ser 5 días después de la fecha de envío."""
         propuesta = self._make_propuesta()
         esperada = propuesta.fecha + timedelta(days=5)

--- a/odoo/addons/actividades_complementarias/tests/test_propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_propuesta_actividad.py
@@ -39,7 +39,9 @@ class TestPropuestaActividad(TransactionCase):
         cls.tipo = cls.env['actividad.tipo'].create({'name': 'Taller Test'})
 
         hoy = date.today()
-        cls.actividad = cls.env['actividad.complementaria'].create({
+        cls.actividad = cls.env['actividad.complementaria'].with_context(
+            skip_fecha_check=True
+        ).create({
             'name': 'Actividad para Propuesta',
             'tipo_actividad_id': cls.tipo.id,
             'periodo': cls.periodo.id,   # Many2one: pasar el ID del registro

--- a/odoo/addons/actividades_complementarias/wizards/wizard_nueva_actividad.py
+++ b/odoo/addons/actividades_complementarias/wizards/wizard_nueva_actividad.py
@@ -1,7 +1,19 @@
 # -*- coding: utf-8 -*-
 from odoo import models, fields, api
 from odoo.exceptions import ValidationError
-from datetime import date
+from datetime import date, timedelta
+
+
+def _n_dias_habiles(n, desde=None):
+    """Avanza *n* días hábiles (lunes a viernes) desde *desde* (default: hoy)."""
+    base = desde if desde is not None else date.today()
+    contados = 0
+    candidato = base
+    while contados < n:
+        candidato += timedelta(days=1)
+        if candidato.weekday() < 5:   # 0=lun … 4=vie
+            contados += 1
+    return candidato
 
 
 class WizardNuevaActividad(models.TransientModel):
@@ -69,8 +81,14 @@ class WizardNuevaActividad(models.TransientModel):
     def _check_fechas(self):
         for rec in self:
             if not self.env.context.get('install_demo') and not self.env.context.get('skip_fecha_check'):
-                if rec.fecha_inicio and rec.fecha_inicio < date.today():
-                    raise ValidationError('La fecha de inicio no puede ser anterior a hoy.')
+                if rec.fecha_inicio:
+                    min_fecha = _n_dias_habiles(5)
+                    if rec.fecha_inicio < min_fecha:
+                        raise ValidationError(
+                            f'La fecha de inicio debe ser al menos 5 días hábiles '
+                            f'a partir de hoy. La fecha mínima válida es '
+                            f'{min_fecha.strftime("%d/%m/%Y")}.'
+                        )
             if rec.fecha_fin and rec.fecha_inicio and rec.fecha_fin <= rec.fecha_inicio:
                 raise ValidationError('La fecha de fin debe ser posterior a la fecha de inicio.')
 


### PR DESCRIPTION
back: Validar que la fecha de inicio de actividad sea mínimo 5 días hábiles a partir del envío (día actual) 
Fixes #42

## Descripción

Agregar un mínimo de espera de cinco días hábiles (Lunes a Viernes) para que una fecha de inicio sea válida a partir del momento de cuando es creada.
Si la actividad fue aceptada, modificar la fecha de inicio de actividad complementaria ahora tomará como punto de partida la fecha del envió de la última propuesta como punto de partida para el tiempo de espera de cinco días hábiles. 

## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [x] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [x] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [x] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [x] Grupos nuevos están declarados en `security/actividades_security.xml`
- [x] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [x] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [x] Linting sin errores (`flake8 --max-line-length=120`)
- [x] No hay `print()`, TODOs ni código comentado en el diff
- [x] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [x] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [x] Si se añade dependencia Python, está en `requirements.txt`