### PR TITLE
JaredReyes107/issue33

### DIFF
--- a/odoo/addons/actividades_complementarias/models/periodo.py
+++ b/odoo/addons/actividades_complementarias/models/periodo.py
@@ -8,4 +8,3 @@ class PeriodoEscolar(models.Model):
     _order = 'name desc'
 
     name = fields.Char(string='Periodo', required=True, help='Ej: 2025-2026, 2025-A, 2026-B')
-    active = fields.Boolean(default=True)

--- a/odoo/addons/actividades_complementarias/views/periodo_views.xml
+++ b/odoo/addons/actividades_complementarias/views/periodo_views.xml
@@ -5,9 +5,10 @@
         <field name="name">actividad.periodo.list</field>
         <field name="model">actividad.periodo</field>
         <field name="arch" type="xml">
-            <list string="Periodos Escolares" editable="bottom">
+            <list string="Periodos Escolares"
+                  create="false" edit="false" delete="false" duplicate="false"
+                  archiving="false">
                 <field name="name"/>
-                <field name="active"/>
             </list>
         </field>
     </record>
@@ -16,11 +17,14 @@
         <field name="name">actividad.periodo.form</field>
         <field name="model">actividad.periodo</field>
         <field name="arch" type="xml">
-            <form string="Periodo Escolar">
+            <form string="Periodo Escolar" create="false" edit="false" delete="false" duplicate="false">
                 <sheet>
+                    <div class="alert alert-info" role="alert">
+                        Los periodos escolares se sincronizan desde una base de datos externa y son de solo lectura.
+                    </div>
                     <group>
-                        <field name="name" placeholder="Ej: 2025-2026, 2025-A"/>
-                        <field name="active"/>
+                        <field name="name" readonly="1"/>
+                        <field name="active" invisible="1"/>
                     </group>
                 </sheet>
             </form>

--- a/odoo/addons/actividades_complementarias/views/periodo_views.xml
+++ b/odoo/addons/actividades_complementarias/views/periodo_views.xml
@@ -6,8 +6,7 @@
         <field name="model">actividad.periodo</field>
         <field name="arch" type="xml">
             <list string="Periodos Escolares"
-                  create="false" edit="false" delete="false" duplicate="false"
-                  archiving="false">
+                  create="false" edit="false" delete="false" duplicate="false">
                 <field name="name"/>
             </list>
         </field>
@@ -24,7 +23,6 @@
                     </div>
                     <group>
                         <field name="name" readonly="1"/>
-                        <field name="active" invisible="1"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
## Descripción

Convierte los periodos a registros de solo lectura.
Fixes #33 

## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [x] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [x] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [x] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [x] Grupos nuevos están declarados en `security/actividades_security.xml`
- [x] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [x] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [x] No hay `print()`, TODOs ni código comentado en el diff
- [x] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [x] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [x] Si se añade dependencia Python, está en `requirements.txt`

## Cómo probar

Acceder como cualquier actor al módulo y comprobar en la vista de 'Periodos' las opciones disponibles.