### PR TITLE
back: Cátalogo de actividades debe ser uniforme para todos los actores

### DIFF
--- a/odoo/addons/actividades_complementarias/security/actividades_security.xml
+++ b/odoo/addons/actividades_complementarias/security/actividades_security.xml
@@ -103,11 +103,16 @@
         <field name="perm_unlink" eval="False"/>
     </record>
 
-    <!-- Responsable de Actividad: solo sus actividades asignadas -->
+    <!-- Responsable de Actividad: sus actividades asignadas Y todo el catálogo -->
     <record id="rule_actividad_responsable" model="ir.rule">
-        <field name="name">Responsable: solo sus actividades asignadas</field>
+        <field name="name">Responsable: sus actividades asignadas y catálogo</field>
         <field name="model_id" ref="model_actividad_complementaria"/>
-        <field name="domain_force">[('responsable_actividad_id', '=', user.id)]</field>
+        <field name="domain_force">
+            ['|',
+                ('responsable_actividad_id', '=', user.id),
+                ('en_catalogo', '=', True)
+            ]
+        </field>
         <field name="groups" eval="[(4, ref('actividades_complementarias.group_responsable_actividad'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="True"/>

--- a/odoo/addons/actividades_complementarias/views/propuesta_views.xml
+++ b/odoo/addons/actividades_complementarias/views/propuesta_views.xml
@@ -106,11 +106,10 @@
     </record>
 
     <record id="action_catalogo_comite" model="ir.actions.act_window">
-        <field name="name">Catalogo de Actividades Aprobadas</field>
+        <field name="name">Catálogo de Actividades</field>
         <field name="res_model">actividad.complementaria</field>
         <field name="view_mode">list,kanban,form</field>
-        <field name="domain">[('estado_code', 'in', ['aprobada','pendiente_inicio','en_curso','finalizada'])]</field>
-        <field name="context">{'search_default_filter_catalogo': 0}</field>
+        <field name="domain">[('en_catalogo', '=', True)]</field>
     </record>
      <!-- Acción para cambiar el texto de propuestas pendientes -->
     <record id="action_propuesta_pendiente" model="ir.actions.act_window">
@@ -140,16 +139,15 @@
 
    <!-- Acción para cambiar el texto de catalogo de actividades -->
    <record id="action_catalogo_comite" model="ir.actions.act_window">
-    <field name="name">Catálogo de Actividades Aprobadas</field>
+    <field name="name">Catálogo de Actividades</field>
     <field name="res_model">actividad.complementaria</field>
     <field name="view_mode">list,kanban,form</field>
-    <field name="domain">[('estado_code', 'in', ['aprobada','pendiente_inicio','en_curso','finalizada'])]</field>
-    <field name="context">{'search_default_filter_catalogo': 0}</field>
+    <field name="domain">[('en_catalogo', '=', True)]</field>
     <field name="help" type="html">
         <p class="o_view_nocontent_smiling_face">
             No hay actividades en el catálogo
         </p>
-        <p>Las actividades aprobadas por el Comité aparecerán aquí.</p>
+        <p>Las actividades enviadas al catálogo por los Jefes de Departamento aparecerán aquí.</p>
     </field>
 </record>
 


### PR DESCRIPTION
Fixes #40

## Descripción

Ahora todos los actores tienen la misma vista al revisar el Catálogo de Actividades

## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [x] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [x] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [x] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [x] Grupos nuevos están declarados en `security/actividades_security.xml`
- [x] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [x] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [x] Linting sin errores (`flake8 --max-line-length=120`)
- [x] No hay `print()`, TODOs ni código comentado en el diff
- [x] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [x] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [x] Si se añade dependencia Python, está en `requirements.txt`

## Cómo probar

Usar usuarios con distintos roles y compronar la vista del Catálogo de Actividades
