### PR TITLE
refactor/modificar los toggle a solo visuales

### DIFF
--- a/odoo/addons/actividades_complementarias/views/empleado_views.xml
+++ b/odoo/addons/actividades_complementarias/views/empleado_views.xml
@@ -30,10 +30,10 @@
                 <field name="no_empleado" string="No. Empleado"/>
                 <field name="departamento_id" string="Departamento"/>
                 <field name="departamento_grupo" string="Rama de Departamento"/>
-                <field name="perm_modificar_actividades" string="Modificar Actividades Complementarias" widget="boolean_toggle"/>
-                <field name="perm_difundir_actividades" string="Difundir Actividades" widget="boolean_toggle"/>
-                <field name="perm_asignar_alumnos" string="Asignar Alumnos a Actividad" widget="boolean_toggle"/>
-                <field name="perm_enviar_catalogo" string="Enviar al Catalogo" widget="boolean_toggle"/>
+                <field name="perm_modificar_actividades" string="Modificar Actividades Complementarias" widget="boolean_toggle" readonly="1"/>
+                <field name="perm_difundir_actividades" string="Difundir Actividades" widget="boolean_toggle" readonly="1"/>
+                <field name="perm_asignar_alumnos" string="Asignar Alumnos a Actividad" widget="boolean_toggle" readonly="1"/>
+                <field name="perm_enviar_catalogo" string="Enviar al Catalogo" widget="boolean_toggle" readonly="1"/>
                 <field name="fecha_ultimo_uso" string="Ultimo Uso"/>
             </list>
         </field>
@@ -101,7 +101,8 @@
                 <sheet>
                     <div class="mb-3 d-flex gap-2">
                         <button string="Guardar" type="object" name="action_guardar_permisos"
-                                class="btn btn-primary"/>
+                                class="btn btn-primary"
+                                confirm="¿Quieres guardar los cambios?"/>
                         <button string="Regresar" type="object" name="action_regresar_lista"
                                 class="btn btn-secondary"/>
                     </div>


### PR DESCRIPTION
## Descripción

fixes#32
se modificaron los toggle, ahora no deverian de poder editarse dede afuera, ademas, se agrego una vista de confirmacion a la hora de guardar los cambios que se le dieron a los usuarios sobre los permisos

## Módulo(s) afectado(s)

views/empleado_views.xml

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`

## Cómo probar

Entrar a jefe de departamento, gestion de personal, no deverian de editarse los toggle y cuando haces algun cambio en los permisos de un usuario, aparece una vista de confirmacion

## Notas para el revisor

_Contexto adicional, decisiones de diseño, trade-offs, áreas de riesgo._
