### PR TITLE
refactor/modificacion en el flujo de una actividad

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -165,6 +165,21 @@ class Actividad(models.Model):
         store=True,
         readonly=True,
     )
+    # Campo Selection nativo para el widget statusbar en vistas
+    # (los campos related no permiten filtrar statusbar_visible correctamente)
+    estado_barra = fields.Selection(
+        selection=[
+            ('en_revision',      'En Revisión'),
+            ('rechazada',        'Rechazada'),
+            ('aprobada',         'Aprobada'),
+            ('pendiente_inicio', 'Pendiente de Inicio'),
+            ('en_curso',         'En Curso'),
+            ('finalizada',       'Finalizada'),
+        ],
+        string='Estado (barra)',
+        compute='_compute_estado_barra',
+        store=True,
+    )
 
     # ── Alumnos asignados ────────────────────────────────────────────────────
     alumno_ids = fields.Many2many(
@@ -521,6 +536,15 @@ class Actividad(models.Model):
     def _compute_constancias_firmadas(self):
         for rec in self:
             rec.constancias_firmadas = rec.jd_firmo and rec.responsable_firmo
+
+    @api.depends('estado_code')
+    def _compute_estado_barra(self):
+        """Sincroniza estado_barra con estado_code para uso exclusivo
+        del widget statusbar en vistas (evita que related muestre
+        todos los valores del Selection de origen).
+        """
+        for rec in self:
+            rec.estado_barra = rec.estado_code or False
 
     @api.depends('alumno_ids')
     def _compute_alumno_count(self):

--- a/odoo/addons/actividades_complementarias/views/actividad_views.xml
+++ b/odoo/addons/actividades_complementarias/views/actividad_views.xml
@@ -66,15 +66,23 @@
                         type="object" class="btn-success"
                         invisible="not actividad_predefinida or en_catalogo or estado_code in ['rechazada','finalizada']"
                         groups="actividades_complementarias.group_jefe_departamento,actividades_complementarias.group_admin_actividades"/>
-                    <!-- Statusbar SIN rechazda (cuando es Nueva Propuesta) -->
-                    <field name="estado_id" widget="statusbar"
-                        statusbar_visible="en_revision,aprobada,pendiente_inicio,en_curso,finalizada"
-                        invisible="not tipo_es_nueva"/>
+                    <!-- Statusbar: solo En Revisión -->
+                    <field name="estado_barra" widget="statusbar"
+                        statusbar_visible="en_revision"
+                        invisible="estado_code != 'en_revision'"
+                        readonly="1"/>
 
-                    <!-- Statusbar CON rechazada (cuando es otro tipo) -->
-                    <field name="estado_id" widget="statusbar"
-                        statusbar_visible="en_revision,aprobada,rechazada,pendiente_inicio,en_curso,finalizada"
-                        invisible="tipo_es_nueva"/>
+                    <!-- Statusbar: solo Rechazada -->
+                    <field name="estado_barra" widget="statusbar"
+                        statusbar_visible="rechazada"
+                        invisible="estado_code != 'rechazada'"
+                        readonly="1"/>
+
+                    <!-- Statusbar: flujo Aprobada → Finalizada -->
+                    <field name="estado_barra" widget="statusbar"
+                        statusbar_visible="aprobada,pendiente_inicio,en_curso,finalizada"
+                        invisible="estado_code not in ['aprobada','pendiente_inicio','en_curso','finalizada']"
+                        readonly="1"/>
                     <button name="action_enviar_catalogo" string="Enviar al Catálogo"
                             type="object" class="btn-primary"
                             invisible="estado_code not in ['aprobada','pendiente_inicio'] or en_catalogo"


### PR DESCRIPTION
## Descripción

Ahora, cuando entres a nueva actividad, el flujo no sera mostrado, cuando la actividad sea rechazada, solo mostrara rechazado, caundo este aprobado, mostrara el flujo completo

Partes de codigo:
---------------views/actividad_views.xml

<!-- VARIANTE 1: Estado = en_revision -->
<field name="estado_barra" widget="statusbar"
    statusbar_visible="en_revision"
    invisible="estado_code != 'en_revision'"
    readonly="1"/>

<!-- VARIANTE 2: Estado = rechazada -->
<field name="estado_barra" widget="statusbar"
    statusbar_visible="rechazada"
    invisible="estado_code != 'rechazada'"
    readonly="1"/>

<!-- VARIANTE 3: Flujo principal aprobada → finalizada  ← la que ves en la imagen -->
<field name="estado_barra" widget="statusbar"
    statusbar_visible="aprobada,pendiente_inicio,en_curso,finalizada"
    invisible="estado_code not in ['aprobada','pendiente_inicio','en_curso','finalizada']"
    readonly="1"/>


-----------models/actividad.py

------------las opciones donde sale el progreso:
estado_barra = fields.Selection(
    selection=[
        ('en_revision',      'En Revisión'),
        ('rechazada',        'Rechazada'),
        ('aprobada',         'Aprobada'),
        ('pendiente_inicio', 'Pendiente de Inicio'),
        ('en_curso',         'En Curso'),
        ('finalizada',       'Finalizada'),
    ],
    string='Estado (barra)',
    compute='_compute_estado_barra',
    store=True,
)



--------------este evita que aparesca cuando se crea la nueva actividad:

@api.depends('estado_code')
def _compute_estado_barra(self):
    for rec in self:
        rec.estado_barra = rec.estado_code or False






## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`

## Cómo probar

_Pasos para verificar el cambio manualmente. Incluir qué usuario demo usar (ej: `jefe.sistemas@ittech.edu.mx`, contraseña `Admin1234!`)._

## Notas para el revisor

_Contexto adicional, decisiones de diseño, trade-offs, áreas de riesgo._
