### PR TITLE
Back:  Escalada de Privilegios: Escritura Directa

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -724,7 +724,7 @@ class Actividad(models.Model):
                 continue
 
             # Otros roles sin gestion especial
-            if not is_jd and not is_admin:
+            if not is_jd:
                 raise UserError(
                     _('No tiene permiso para modificar actividades complementarias.')
                 )

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -724,8 +724,10 @@ class Actividad(models.Model):
                 continue
 
             # Otros roles sin gestion especial
-            if not is_jd:
-                continue
+            if not is_jd and not is_admin:
+                raise UserError(
+                    _('No tiene permiso para modificar actividades complementarias.')
+                )
 
             # ── A partir de aqui: usuario es JD (no admin) ──
 

--- a/odoo/addons/actividades_complementarias/tests/test_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_actividad.py
@@ -38,6 +38,9 @@ class TestActividad(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env.user.group_ids |= cls.env.ref(
+            'actividades_complementarias.group_admin_actividades'
+        )
         # Estados — definidos en estado_actividad_data.xml
         cls.estado_aprobada = cls.env.ref('actividades_complementarias.estado_aprobada')
         cls.estado_finalizada = cls.env.ref('actividades_complementarias.estado_finalizada')

--- a/odoo/addons/actividades_complementarias/tests/test_propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/tests/test_propuesta_actividad.py
@@ -19,6 +19,9 @@ class TestPropuestaActividad(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env.user.group_ids |= cls.env.ref(
+            'actividades_complementarias.group_comite_academico'
+        )
         # Estados de solicitud — definidos en estado_solicitud_data.xml
         cls.estado_sol_en_revision = cls.env.ref(
             'actividades_complementarias.estado_solicitud_en_revision'


### PR DESCRIPTION
Fixes #105

## Descripción

Implementar política de rechazo en el método write(), permitiendo solo a env.su o roles explícitamente
autorizados realizar escrituras

## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
