### PR TITLE
Añadir token de acceso a la URL de descarga de archivos adjuntos

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -1312,11 +1312,12 @@ class Actividad(models.Model):
             'res_model': self._name,
             'res_id': self.id,
         })
+        access_token = attachment.sudo().generate_access_token()[0]
 
         # Devolver descarga directa del ZIP
         return {
             'type': 'ir.actions.act_url',
-            'url': f'/web/content/{attachment.id}?download=true',
+            'url': f'/web/content/{attachment.id}?access_token={access_token}&download=true',
             'target': 'self',
         }
 


### PR DESCRIPTION
## Descripción

Se añade un token de acceso a la URL de descarga de archivos adjuntos para mejorar la seguridad y el control de acceso a los archivos.

## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [x] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`

## Cómo probar

1. Iniciar sesión con un usuario que tenga acceso a las actividades complementarias.
2. Intentar descargar un archivo adjunto y verificar que la URL incluye el token de acceso.
3. Confirmar que el archivo se descarga correctamente.

## Notas para el revisor

Se implementó esta funcionalidad para asegurar que solo los usuarios autorizados puedan acceder a los archivos adjuntos. Se recomienda revisar el manejo de tokens en el sistema.

