### PR TITLE
Añadir verificación de permisos para la operación de escritura en el modelo Actividad

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -669,6 +669,11 @@ class Actividad(models.Model):
         """
         # Las acciones internas del sistema omiten la protección
         if self.env.context.get('bypass_edit_protection'):
+            is_admin = self.env.user.has_group(
+                'actividades_complementarias.group_admin_actividades'
+            )
+            if not (self.env.su or is_admin):
+                raise UserError(_('Operacion no permitida.'))
             return super().write(vals)
 
         is_admin = self.env.user.has_group(


### PR DESCRIPTION
## Descripción

Se implementa una verificación de permisos para la operación de escritura en el modelo `Actividad`, asegurando que solo los administradores o usuarios con permisos adecuados puedan realizar esta acción.

## Módulo(s) afectado(s)

- `actividades_complementarias`

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [x] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`

## Cómo probar

Iniciar sesión como un usuario que no tenga permisos de administrador y intentar realizar una operación de escritura en el modelo `Actividad`. Debería aparecer un error de operación no permitida.

## Notas para el revisor

Se añadió una verificación de permisos para mejorar la seguridad en las operaciones de escritura. Asegurarse de que los cambios no afecten otras funcionalidades relacionadas.

