### PR TITLE
feat: -> agrega los colores de advertencia

### DIFF
--- a/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
@@ -45,9 +45,7 @@ class PropuestaActividadComplementaria(models.Model):
         compute='_compute_urgencia_limite',
         store=False,
         )
-
     
-
     # ── Estado ───────────────────────────────────────────────────────────────
     estado_solicitud_id = fields.Many2one(
         'actividad.estado.solicitud',
@@ -114,9 +112,9 @@ class PropuestaActividadComplementaria(models.Model):
     def _compute_urgencia_limite(self):
         hoy = date.today()
         for rec in self:
-         if rec.estado_code != 'en_revision' or not rec.fecha_limite_revision:
-            rec.urgencia_limite = 'verde'
-            continue
+            if rec.estado_code != 'en_revision' or not rec.fecha_limite_revision:
+                rec.urgencia_limite = 'verde'
+                continue
         dias = (rec.fecha_limite_revision - hoy).days
         if dias > 3:
             rec.urgencia_limite = 'verde'
@@ -124,7 +122,6 @@ class PropuestaActividadComplementaria(models.Model):
             rec.urgencia_limite = 'naranja'
         else:
             rec.urgencia_limite = 'rojo'
-
 
     def _partner_jd(self):
         self.ensure_one()

--- a/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
@@ -37,6 +37,17 @@ class PropuestaActividadComplementaria(models.Model):
         help='La propuesta se aprueba automáticamente si no hay respuesta en 5 días hábiles.',
     )
 
+    urgencia_limite = fields.Selection([
+         ('verde',   'Verde'),
+         ('naranja', 'Naranja'),
+         ('rojo',    'Rojo'),
+        ], string='Urgencia Límite',
+        compute='_compute_urgencia_limite',
+        store=False,
+        )
+
+    
+
     # ── Estado ───────────────────────────────────────────────────────────────
     estado_solicitud_id = fields.Many2one(
         'actividad.estado.solicitud',
@@ -98,6 +109,22 @@ class PropuestaActividadComplementaria(models.Model):
                 rec.fecha_limite_revision = rec.fecha + timedelta(days=5)
             else:
                 rec.fecha_limite_revision = False
+
+    @api.depends('fecha_limite_revision', 'estado_code')
+    def _compute_urgencia_limite(self):
+        hoy = date.today()
+        for rec in self:
+         if rec.estado_code != 'en_revision' or not rec.fecha_limite_revision:
+            rec.urgencia_limite = 'verde'
+            continue
+        dias = (rec.fecha_limite_revision - hoy).days
+        if dias > 3:
+            rec.urgencia_limite = 'verde'
+        elif 1 <= dias <= 3:
+            rec.urgencia_limite = 'naranja'
+        else:
+            rec.urgencia_limite = 'rojo'
+
 
     def _partner_jd(self):
         self.ensure_one()

--- a/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
@@ -45,7 +45,6 @@ class PropuestaActividadComplementaria(models.Model):
         compute='_compute_urgencia_limite',
         store=False,
         )
-    
     # ── Estado ───────────────────────────────────────────────────────────────
     estado_solicitud_id = fields.Many2one(
         'actividad.estado.solicitud',

--- a/odoo/addons/actividades_complementarias/views/propuesta_views.xml
+++ b/odoo/addons/actividades_complementarias/views/propuesta_views.xml
@@ -14,9 +14,9 @@
                 <field name="fecha" string="Enviada"/>
                 <field name="fecha_limite_revision" string="Limite"/>
                 <field name="estado_solicitud_id" string="Estado" widget="badge"
-                       decoration-warning="estado_code == 'en_revision'"
-                       decoration-success="estado_code == 'aprobada'"
-                       decoration-danger="estado_code == 'rechazada'"/>
+                    decoration-warning="estado_code == 'en_revision'"
+                    decoration-success="estado_code == 'aprobada'"
+                    decoration-danger="estado_code == 'rechazada'"/>
                 <field name="estado_code" column_invisible="1"/>
             </list>
         </field>


### PR DESCRIPTION
## Descripción

rchivos modificados
models/propuesta_actividad.py

Campo urgencia_limite computado según proximidad a fecha límite
Método _compute_urgencia_limite con lógica verde/naranja/rojo

views/propuesta_views.xml

Vista lista con default_order="fecha_limite_revision asc"
Decoraciones de color en columna "Límite" según urgencia_limite
Campo urgencia_limite invisible en la lista