### PR TITLE
Back: Reparar el botón de regresar en el formulario de modificación de los permisos del personal de departamento

### DIFF
--- a/odoo/addons/actividades_complementarias/__manifest__.py
+++ b/odoo/addons/actividades_complementarias/__manifest__.py
@@ -49,6 +49,7 @@
             'actividades_complementarias/static/src/xml/dark_mode_switch.xml',
             'actividades_complementarias/static/src/js/dark_mode_switch.js',
             'actividades_complementarias/static/src/js/navbar_chevron.js',
+            'actividades_complementarias/static/src/js/form_discard_patch.js',
         ],
     },
     'demo': [

--- a/odoo/addons/actividades_complementarias/static/src/js/form_discard_patch.js
+++ b/odoo/addons/actividades_complementarias/static/src/js/form_discard_patch.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+import { FormController } from "@web/views/form/form_controller";
+import { patch } from "@web/core/utils/patch";
+
+patch(FormController.prototype, {
+    async beforeLeave() {
+        if (
+            this.model.root.isDirty &&
+            this.model.root.resModel === "actividad.empleado.permiso"
+        ) {
+            const guardar = window.confirm(
+                "¿Desea guardar los cambios antes de salir?"
+            );
+            if (guardar) {
+                await this.model.root.save();
+            } else {
+                this.model.root.discard();
+            }
+            return true;
+        }
+        return super.beforeLeave?.();
+    },
+});


### PR DESCRIPTION
Fixes #149

## Descripción

Se añadió una ventana emergente que interrumpe al usuario cuando trata de navegar a otra pantaña desde la gestión de permisos sin haber guardado

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios en el modelo `actividad.complementaria`, se verificó que no rompe `jd_firmo`/`responsable_firmo`/`constancias_firmadas`
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
