### PR TITLE
Deshabilitar creación de formularios en vistas de actividad complementaria y propuesta

### DIFF
--- a/odoo/addons/actividades_complementarias/views/actividad_views.xml
+++ b/odoo/addons/actividades_complementarias/views/actividad_views.xml
@@ -69,7 +69,7 @@
         <field name="name">actividad.complementaria.form</field>
         <field name="model">actividad.complementaria</field>
         <field name="arch" type="xml">
-            <form string="Actividad Complementaria">
+            <form string="Actividad Complementaria" create="0">
                 <header>
                     <button name="action_abrir_confirmacion_comite" string="Enviar al Comité Académico"
                         type="object" class="btn-warning"

--- a/odoo/addons/actividades_complementarias/views/propuesta_views.xml
+++ b/odoo/addons/actividades_complementarias/views/propuesta_views.xml
@@ -53,7 +53,7 @@
         <field name="name">actividad.propuesta.form</field>
         <field name="model">actividad.propuesta</field>
         <field name="arch" type="xml">
-            <form string="Propuesta al Comite Academico">
+            <form string="Propuesta al Comite Academico" create="0">
                 <header>
                     <button name="action_abrir_wizard_aprobacion" string="Aprobar"
                             type="object" class="btn-success"


### PR DESCRIPTION
## Descripción

Se deshabilita la creación de formularios en las vistas de actividad complementaria y propuesta para evitar la creación no deseada de registros.

## Tipo de cambio

- [x] `fix` — Corrección de bug

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`

