### PR TITLE
feat(ui): agregar campo horario por día en formulario de propuesta

### DIFF
--- a/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
@@ -78,6 +78,11 @@ class PropuestaActividadComplementaria(models.Model):
         string='Cupo',
         compute='_compute_actividad_cupo',
     )
+    actividad_horario = fields.Text(
+        related='actividad_id.horario',
+        string='Horario por Día',
+        readonly=True,
+    )
 
     # ────────────────────────────────────────────────────────────────────────
     # Computes

--- a/odoo/addons/actividades_complementarias/views/propuesta_views.xml
+++ b/odoo/addons/actividades_complementarias/views/propuesta_views.xml
@@ -97,6 +97,7 @@
                             <field name="actividad_jefe" readonly="1" string="Jefe de Departamento"/>
                             <field name="actividad_departamento" readonly="1" string="Departamento"/>
                             <field name="actividad_periodo" readonly="1" string="Periodo"/>
+                            <field name="actividad_horario" readonly="1" string="Horario"/>
                         </group>
                         <group>
                             <field name="actividad_fecha_inicio" readonly="1" string="Fecha de Inicio"/>


### PR DESCRIPTION
 Campo "Horario por Día" en formulario de propuesta
Se agregó el campo actividad_horario en la sección "Detalle de la Actividad Propuesta" del formulario de propuesta, permitiendo al Comité Académico ver el horario al revisar una propuesta. archivos modificados: propuesta_actividad.py y propuestas_views.xml