### PR TITLE
fix/Añadir restricción para evitar la duplicación de actividades

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -304,6 +304,12 @@ class Actividad(models.Model):
         compute='_compute_responsable_readonly',
     )
 
+    # ── Restricción de duplicación ──────────────────────────────────────────
+    def copy(self, default=None):
+        raise UserError(_(
+            "Acción no valida, no es posible duplicar actividades"
+        ))
+
     @api.depends('estado_code')
     def _compute_responsable_readonly(self):
         is_jd = self.env.user.has_group(

--- a/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
+++ b/odoo/addons/actividades_complementarias/models/propuesta_actividad.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError, UserError
 from datetime import date, timedelta
 from markupsafe import Markup
@@ -87,6 +87,11 @@ class PropuestaActividadComplementaria(models.Model):
     # ────────────────────────────────────────────────────────────────────────
     # Computes
     # ────────────────────────────────────────────────────────────────────────
+
+    def copy(self, default=None):
+        raise UserError(_(
+            "Acción no valida, no es posible duplicar actividades"
+        ))
 
     @api.depends('actividad_id')
     def _compute_encabezado(self):


### PR DESCRIPTION
## Descripción

Se implementa una restricción para evitar la duplicación de actividades, lanzando un error cuando se intenta copiar una actividad existente.

## Tipo de cambio

- [x] `fix` — Corrección de bug

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`

