### PR TITLE
Refactor/Modificar-barra-navegacion-estudiante

### DIFF
--- a/odoo/addons/actividades_complementarias/views/alumno_views.xml
+++ b/odoo/addons/actividades_complementarias/views/alumno_views.xml
@@ -22,7 +22,9 @@
                             type="object" class="btn-danger"
                             invisible="not alumno_inscrito
                                        or estado_code == 'finalizada'"/>
-                    <field name="estado_id" widget="statusbar" readonly="1"/>
+                    <field name="estado_barra" widget="statusbar"
+                           statusbar_visible="pendiente_inicio,en_curso,finalizada"
+                           readonly="1"/>
                     <button name="action_abrir_evidencia"
                             string="Subir Evidencia"
                             type="object" class="btn-secondary"


### PR DESCRIPTION
Se modifico la barra de navegacion del estudiante, el flujo solo muestra cuando una actividad esta pendiente por iniciar, cuando esta en curso y cuando finaliza

## Descripción

_¿Qué cambia y por qué? Referencia el caso de uso (ej: implementa E-01SC — inscripción de estudiante)._

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
