### PR TITLE
refactor/Eliminar-cambio-toggle

### DIFF
--- a/odoo/addons/actividades_complementarias/views/tipo_predefinida_views.xml
+++ b/odoo/addons/actividades_complementarias/views/tipo_predefinida_views.xml
@@ -8,7 +8,7 @@
             <list string="Actividades Predefinidas">
                 <field name="name" string="Nombre"/>
                 <field name="tipo_actividad_id" string="Tipo de Actividad"/>
-                <field name="is_comite" string="Aprobado por Comité" widget="boolean_toggle"/>
+                <field name="is_comite" string="Aprobado por Comité" widget="boolean" readonly="1" width="200px"/>
                 <field name="actividad_origen_id" string="Actividad de Origen" optional="show"/>
                 <field name="active" string="Activo" optional="show"/>
             </list>


### PR DESCRIPTION
Se eliminaron los toggle por palomitas de la vista configurasion/actividades pre definidas, se elimino la capasidad de editar esos datos desde la visata

## Descripción

_¿Qué cambia y por qué? Referencia el caso de uso (ej: implementa E-01SC — inscripción de estudiante)._

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
