### PR TITLE
Refactor/Separar-opciones-alumno

### DIFF
--- a/odoo/addons/actividades_complementarias/static/src/scss/style.scss
+++ b/odoo/addons/actividades_complementarias/static/src/scss/style.scss
@@ -30,6 +30,13 @@ body:has(.o_menu_brand[data-menu-xmlid^="actividades_complementarias"]) {
         padding-top: 12px !important;
     }
 
+    /* Separador antes de Mis Inscripciones en menú Alumno */
+    a[data-menu-xmlid="actividades_complementarias.menu_alumno_inscripciones"] {
+        border-top: 1px solid rgba(0, 0, 0, 0.15) !important;
+        margin-top: 4px !important;
+        padding-top: 12px !important;
+    }
+
     /* ── Empty state: reemplaza el muñeco por el logo del TecNM ── */
     .o_nocontent_help .o_nocontent_image,
     .o_view_nocontent .o_nocontent_image {
@@ -538,6 +545,11 @@ body.ac_dark_mode:has(.o_menu_brand[data-menu-xmlid^="actividades_complementaria
 
     /* Separador Gestión de Personal en modo oscuro */
     a[data-menu-xmlid="actividades_complementarias.menu_gestion_personal"] {
+        border-top-color: rgba(255, 255, 255, 0.2) !important;
+    }
+
+    /* Separador Mis Inscripciones (menú Alumno) en modo oscuro */
+    a[data-menu-xmlid="actividades_complementarias.menu_alumno_inscripciones"] {
         border-top-color: rgba(255, 255, 255, 0.2) !important;
     }
 


### PR DESCRIPTION
Se separaron las opciones catálogo de actividades y mis inscripciones con una línea en el módulo alumnos

## Descripción

_¿Qué cambia y por qué? Referencia el caso de uso (ej: implementa E-01SC — inscripción de estudiante)._

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
