### PR TITLE
refactor/Correciones-modo-oscuro

### DIFF
--- a/odoo/addons/actividades_complementarias/static/src/scss/style.scss
+++ b/odoo/addons/actividades_complementarias/static/src/scss/style.scss
@@ -28,6 +28,15 @@ body:has(.o_menu_brand[data-menu-xmlid^="actividades_complementarias"]) {
         border-top: 1px solid rgba(0, 0, 0, 0.15) !important;
         margin-top: 4px !important;
         padding-top: 12px !important;
+        box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.15) !important;
+    }
+
+    /* Separador antes de Mis Inscripciones en menú Alumno */
+    a[data-menu-xmlid="actividades_complementarias.menu_alumno_inscripciones"] {
+        border-top: 1px solid rgba(0, 0, 0, 0.15) !important;
+        margin-top: 4px !important;
+        padding-top: 12px !important;
+        box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.15) !important;
     }
 
     /* ── Empty state: reemplaza el muñeco por el logo del TecNM ── */
@@ -175,6 +184,7 @@ a[data-menu-xmlid="actividades_complementarias.menu_catalogo_comite"] {
     border-top: 1px solid rgba(0, 0, 0, 0.15) !important;
     margin-top: 4px !important;
     padding-top: 12px !important;
+    box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.15) !important;
 }
 
 /* Navbar SOLO cuando estás dentro de Actividades Complementarias */
@@ -541,6 +551,11 @@ body.ac_dark_mode:has(.o_menu_brand[data-menu-xmlid^="actividades_complementaria
         border-top-color: rgba(255, 255, 255, 0.2) !important;
     }
 
+    /* Separador Mis Inscripciones (menú Alumno) en modo oscuro */
+    a[data-menu-xmlid="actividades_complementarias.menu_alumno_inscripciones"] {
+        border-top-color: rgba(255, 255, 255, 0.2) !important;
+    }
+
     /* Palomita verde en modo oscuro */
     .o_field_boolean input[type="checkbox"]:checked {
         background-color: #28a745 !important;
@@ -582,6 +597,8 @@ body:has(.o_menu_brand[data-menu-xmlid^="actividades_complementarias"]) {
         color: #000000 !important;
         font-weight: 700 !important;
         opacity: 1 !important;
+        background-color: #F06702 !important;
+        border-radius: 4px !important;
     }
 }
 


### PR DESCRIPTION
Se realiso un cambio menor al modo oscuro, ahora se indica en que sección está el usuario con un contorno naranja, tambien aplica al modo claro

## Descripción

_¿Qué cambia y por qué? Referencia el caso de uso (ej: implementa E-01SC — inscripción de estudiante)._

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
