### PR TITLE
fix: Mostrar el botón de "Enviar al Catálogo" para JDs y personal del departamento apropiado

### DIFF
--- a/odoo/addons/actividades_complementarias/views/actividad_views.xml
+++ b/odoo/addons/actividades_complementarias/views/actividad_views.xml
@@ -104,7 +104,7 @@
                     <!-- Botón para actividades predefinidas (sin pasar por el Comité) -->
                     <button name="action_abrir_confirmacion_catalogo" string="Enviar al Catálogo"
                         type="object" class="btn-primary"
-                        invisible="not actividad_predefinida or en_catalogo or (estado_code and estado_code not in ['pendiente_inicio','aprobada'])"
+                        invisible="(not actividad_predefinida and estado_code not in ['aprobada', 'pendiente_inicio']) or en_catalogo"
                         groups="actividades_complementarias.group_jefe_departamento,actividades_complementarias.group_admin_actividades,actividades_complementarias.group_personal_departamento_sistemas,actividades_complementarias.group_personal_departamento_electrica,actividades_complementarias.group_personal_departamento_biologia"/>
                     <!-- Botón Enviar al Catálogo para DE (actividades extraescolar sin Comité) -->
                     <button name="action_abrir_confirmacion_catalogo" string="Enviar al Catálogo"


### PR DESCRIPTION
Fixes #226

## Descripción

Reutiliza el botón para enviar al catálogo actividades predefinidas, mostrándolo también para actividades no predefinidas aprobadas por el Comité Académico

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [x] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
