### PR TITLE
fix: Campo 'Tipo de Actividad' editable para Personal de departamento

### DIFF
--- a/odoo/addons/actividades_complementarias/views/actividad_views.xml
+++ b/odoo/addons/actividades_complementarias/views/actividad_views.xml
@@ -230,7 +230,8 @@
                             <field name="tipo_actividad_id"
                                 readonly="estado_code in ['aprobada','pendiente_inicio','en_curso','finalizada','en_revision'] or es_personal"
                                 groups="actividades_complementarias.group_jefe_departamento,actividades_complementarias.group_admin_actividades"/>
-                            <field name="tipo_actividad_id" readonly="1"
+                            <field name="tipo_actividad_id"
+                                readonly="actividad_predefinida or estado_code in ['aprobada','pendiente_inicio','en_curso','finalizada','en_revision']"
                                 groups="actividades_complementarias.group_personal_departamento_sistemas,actividades_complementarias.group_personal_departamento_electrica,actividades_complementarias.group_personal_departamento_biologia"/>
                             <field name="dominio_predefinida" invisible="1"/>
                             <field name="actividad_predefinida"


### PR DESCRIPTION
Fixes #228

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
