### PR TITLE
JaredReyes107/issue234

### DIFF
--- a/odoo/addons/actividades_complementarias/models/solicitud_liberacion.py
+++ b/odoo/addons/actividades_complementarias/models/solicitud_liberacion.py
@@ -207,6 +207,19 @@ class SolicitudLiberacion(models.Model):
                     'Ya existe una solicitud activa (En Revisión o Aprobada) '
                     'para este estudiante. Solo puede haber una a la vez.'
                 )
+ 
+    @api.constrains('estudiante_id')
+    def _check_estudiante_es_usuario(self):
+        """E-03SC: el estudiante de la solicitud debe ser el usuario autenticado."""
+        for rec in self:
+            if (
+                not self.env.user.has_group('actividades_complementarias.group_admin_actividades')
+                and not self.env.user.has_group('actividades_complementarias.group_servicios_escolares')
+                and rec.estudiante_id.id != self.env.user.id
+            ):
+                raise ValidationError(
+                    'Solo puedes crear solicitudes de liberación a tu propio nombre.'
+                )
 
     # ────────────────────────────────────────────────────────────────────────
     # Business logic

--- a/odoo/addons/actividades_complementarias/models/solicitud_liberacion.py
+++ b/odoo/addons/actividades_complementarias/models/solicitud_liberacion.py
@@ -207,7 +207,7 @@ class SolicitudLiberacion(models.Model):
                     'Ya existe una solicitud activa (En Revisión o Aprobada) '
                     'para este estudiante. Solo puede haber una a la vez.'
                 )
- 
+
     @api.constrains('estudiante_id')
     def _check_estudiante_es_usuario(self):
         """E-03SC: el estudiante de la solicitud debe ser el usuario autenticado."""

--- a/odoo/addons/actividades_complementarias/security/actividades_security.xml
+++ b/odoo/addons/actividades_complementarias/security/actividades_security.xml
@@ -425,6 +425,17 @@
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>
     </record>
+
+    <record id="rule_solicitud_liberacion_alumno" model="ir.rule">
+        <field name="name">Alumno: solo su propia solicitud de liberación</field>
+        <field name="model_id" ref="model_actividad_solicitud_liberacion"/>
+        <field name="domain_force">[('estudiante_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('actividades_complementarias.group_alumno'))]"/>
+        <field name="perm_read"   eval="True"/>
+        <field name="perm_write"  eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
     <!-- ════════════════════════════════════════════════════════════════════
          Record rules — Departamento de Extraescolares (DE)
          Misma lógica que JD: escritura solo sobre sus propias actividades.


### PR DESCRIPTION
Fixes #234 

## Descripción

Agrega una restricción de modelo y una regla a nivel ORM para validar que
el estudiante asignado a la solicitud coincide exactamente con el usuario autenticado

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
