### PR TITLE
fix: Prevent RA from modifying auto-managed fields and submitted activities

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -1201,8 +1201,23 @@ class Actividad(models.Model):
                         )
                 continue
 
-            # Reemplazar por ¿if is_ra and (not rec.id or rec.responsable_actividad_id.id == self.env.user.id):?
             if is_ra and rec.responsable_actividad_id.id == self.env.user.id:
+                # RA nunca puede modificar campos auto-gestionados por el sistema
+                campos_auto_solicitados = set(vals.keys()) & self._CAMPOS_AUTO_JD
+                if campos_auto_solicitados:
+                    raise UserError(
+                        _('Los siguientes campos son gestionados automáticamente '
+                          'por el sistema y no pueden modificarse directamente: %s.')
+                        % ', '.join(sorted(campos_auto_solicitados))
+                    )
+                # Una vez enviada la actividad, el RA no modifica campos directamente.
+                # Todas sus operaciones legítimas usan bypass_edit_protection=True.
+                if rec.estado_code:
+                    raise UserError(
+                        _('La actividad "%s" ya fue enviada. El Responsable de '
+                          'Actividad no puede modificar sus datos directamente.')
+                        % rec.name
+                    )
                 continue
 
             # ── Personal de Departamento ──────────────────────────────────────


### PR DESCRIPTION
Fixes #237

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
