### PR TITLE
feat(ui): ocultar botones de evidencias, sesiones y evaluación según permisos

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -2681,4 +2681,3 @@ class ActividadDepartamento(models.Model):
 
     name = fields.Char(string='Nombre', required=True)
     jefe_id = fields.Many2one('res.users', string='Jefe de Departamento')
-    

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -2681,3 +2681,4 @@ class ActividadDepartamento(models.Model):
 
     name = fields.Char(string='Nombre', required=True)
     jefe_id = fields.Many2one('res.users', string='Jefe de Departamento')
+    

--- a/odoo/addons/actividades_complementarias/models/actividad.py
+++ b/odoo/addons/actividades_complementarias/models/actividad.py
@@ -463,6 +463,32 @@ class Actividad(models.Model):
         for rec in self:
             rec.es_personal = is_personal
 
+    es_responsable_de_actividad = fields.Boolean(
+        compute='_compute_es_responsable_de_actividad',
+        store=False,
+    )
+    es_jefe_o_admin = fields.Boolean(
+        compute='_compute_es_jefe_o_admin',
+        store=False,
+    )
+
+    @api.depends('responsable_actividad_id')
+    def _compute_es_responsable_de_actividad(self):
+        for rec in self:
+            rec.es_responsable_de_actividad = (
+                rec.responsable_actividad_id.id == self.env.user.id
+            )
+
+    @api.depends('jefe_departamento_id')
+    def _compute_es_jefe_o_admin(self):
+        is_admin = self.env.user.has_group(
+            'actividades_complementarias.group_admin_actividades'
+        )
+        for rec in self:
+            rec.es_jefe_o_admin = (
+                rec.jefe_departamento_id.id == self.env.user.id or is_admin
+            )
+
     def _get_permiso_personal(self):
         """Devuelve el registro EmpleadoPermiso del usuario en sesion o vacio."""
         return self.env['actividad.empleado.permiso'].sudo().search(
@@ -2655,3 +2681,4 @@ class ActividadDepartamento(models.Model):
 
     name = fields.Char(string='Nombre', required=True)
     jefe_id = fields.Many2one('res.users', string='Jefe de Departamento')
+    

--- a/odoo/addons/actividades_complementarias/views/actividad_views.xml
+++ b/odoo/addons/actividades_complementarias/views/actividad_views.xml
@@ -181,6 +181,8 @@
                     <field name="dominio_responsable" invisible="1"/>
                     <field name="dominio_alumnos" invisible="1"/>
                     <field name="es_personal" invisible="1"/>
+                    <field name="es_responsable_de_actividad" invisible="1"/>
+                    <field name="es_jefe_o_admin" invisible="1"/>
                     <!-- Flags de permisos de edición (calculados por rol y estado) -->
                     <field name="permisos_actividad_finalizada" invisible="1"/>
                     <field name="permisos_actividad_en_curso" invisible="1"/>
@@ -219,7 +221,7 @@
                                 type="object"
                                 class="oe_stat_button"
                                 icon="fa-calendar-check-o"
-                                invisible="estado_code not in ['en_curso','finalizada'] or certificates_generated"
+                                invisible="estado_code not in ['en_curso','finalizada'] or certificates_generated or (not es_responsable_de_actividad and not es_jefe_o_admin)"
                                 groups="actividades_complementarias.group_responsable_actividad,actividades_complementarias.group_responsable_actividad_extraescolar,actividades_complementarias.group_jefe_departamento,actividades_complementarias.group_admin_actividades">
                             <field name="asistencia_count" widget="statinfo" string="Sesiones"/>
                         </button>
@@ -228,7 +230,7 @@
                                 type="object"
                                 class="oe_stat_button"
                                 icon="fa-star"
-                                invisible="estado_code != 'finalizada'"
+                                invisible="estado_code != 'finalizada' or (not es_responsable_de_actividad and not es_jefe_o_admin)"
                                 groups="actividades_complementarias.group_responsable_actividad,actividades_complementarias.group_responsable_actividad_extraescolar,actividades_complementarias.group_jefe_departamento,actividades_complementarias.group_admin_actividades">
                             <field name="inscripcion_count" widget="statinfo" string="Estudiantes"/>
                         </button>
@@ -415,7 +417,7 @@
                 <button name="action_toggle_evidence"
                         type="object"
                         class="btn-secondary"
-                        invisible="estado_code not in ['en_curso', 'finalizada']"
+                        invisible="estado_code not in ['en_curso', 'finalizada'] or not es_responsable_de_actividad"
                         groups="actividades_complementarias.group_responsable_actividad,actividades_complementarias.group_responsable_actividad_extraescolar">
                     <span invisible="evidence_enabled">Habilitar Evidencias</span>
                     <span invisible="not evidence_enabled">Deshabilitar Evidencias</span>
@@ -446,6 +448,7 @@
             <!-- ── Campos de control invisibles (usados en botones del header) -->
             <xpath expr="//field[@name='responsable_bloqueado']" position="after">
                 <field name="evidence_enabled" invisible="1"/>
+                <field name="es_responsable_de_actividad" invisible="1"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Descripción

se ocultan botones segun los permisos, se modificaron los archivos actividad.py (linea 456 a 490) y actividad_views.xml