### PR TITLE
Añadir control de permisos para evaluación de alumnos en la actividad

### DIFF
--- a/odoo/addons/actividades_complementarias/models/actividad_inscripcion.py
+++ b/odoo/addons/actividades_complementarias/models/actividad_inscripcion.py
@@ -103,9 +103,27 @@ class ActividadInscripcion(models.Model):
         store=True,
     )
 
+    puede_evaluar = fields.Boolean(
+        string="Puede Evaluar",
+        compute="_compute_puede_evaluar",
+        help=(
+            "Verdadero únicamente cuando el usuario en sesión es el "
+            "Responsable de la Actividad. El Jefe de Departamento no puede "
+            "evaluar alumnos aunque tenga acceso de lectura a la actividad."
+        ),
+    )
+
     # ------------------------------------------------------------------
     # Computes
     # ------------------------------------------------------------------
+
+    @api.depends("actividad_id.responsable_actividad_id")
+    def _compute_puede_evaluar(self):
+        uid = self.env.user.id
+        for rec in self:
+            rec.puede_evaluar = (
+                rec.actividad_id.responsable_actividad_id.id == uid
+            )
 
     @api.depends("performance_level")
     def _compute_performance_label(self):
@@ -149,8 +167,21 @@ class ActividadInscripcion(models.Model):
         return super().write(vals)
 
     def action_evaluar(self):
-        """Abre el wizard para asignar nivel de desempeño a este alumno."""
+        """Abre el wizard para asignar nivel de desempeño a este alumno.
+
+        Solo puede ejecutarse si el usuario en sesión es el Responsable de
+        la Actividad.  El Jefe de Departamento (y cualquier otro rol) recibe
+        un error de permisos aunque logre llamar la acción manualmente.
+        """
         self.ensure_one()
+        if not self.puede_evaluar:
+            raise ValidationError(
+                _(
+                    "No tiene permiso para evaluar alumnos en esta actividad. "
+                    "Solo el Responsable de la Actividad puede asignar el "
+                    "nivel de desempeño."
+                )
+            )
         if self.performance_level:
             raise ValidationError(
                 _(

--- a/odoo/addons/actividades_complementarias/views/actividad_inscripcion_views.xml
+++ b/odoo/addons/actividades_complementarias/views/actividad_inscripcion_views.xml
@@ -32,8 +32,10 @@
                 <field name="certificate_generated" readonly="1"/>
                 <field name="jd_signed" readonly="1"/>
                 <field name="ra_signed" readonly="1"/>
+                <field name="puede_evaluar" column_invisible="1"/>
                 <button name="action_evaluar" string="Evaluar"
-                        type="object" icon="fa-pencil" class="btn-sm btn-primary"/>
+                        type="object" icon="fa-pencil" class="btn-sm btn-primary"
+                        invisible="not puede_evaluar"/>
             </list>
         </field>
     </record>

--- a/odoo/addons/actividades_complementarias/wizards/wizard_evaluar_alumno.py
+++ b/odoo/addons/actividades_complementarias/wizards/wizard_evaluar_alumno.py
@@ -53,6 +53,16 @@ class WizardEvaluarAlumno(models.TransientModel):
 
     def action_confirmar(self):
         self.ensure_one()
+        # Verificar que el usuario en sesión es el Responsable de la Actividad
+        inscripcion = self.inscripcion_id
+        if inscripcion.actividad_id.responsable_actividad_id.id != self.env.user.id:
+            raise ValidationError(
+                _(
+                    "No tiene permiso para evaluar alumnos en esta actividad. "
+                    "Solo el Responsable de la Actividad puede asignar el "
+                    "nivel de desempeño."
+                )
+            )
         if self.inscripcion_id.performance_level:
             raise ValidationError(
                 _(


### PR DESCRIPTION
## Descripción

_¿Qué cambia y por qué? Referencia el caso de uso (ej: implementa E-01SC — inscripción de estudiante)._

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
