### PR TITLE
Añadir restricciones para el grupo Jefe de Departamento en la modificación de asistencias

### DIFF
--- a/odoo/addons/actividades_complementarias/controllers/pase_lista_pivot.py
+++ b/odoo/addons/actividades_complementarias/controllers/pase_lista_pivot.py
@@ -68,6 +68,15 @@ class PaseListaPivotController(http.Controller):
     )
     def toggle_asistencia(self, asistencia_id, presente, **kw):
         """Actualiza presente/ausente de un registro de asistencia."""
+        # Restricción: Jefe de Departamento no puede modificar asistencias
+        if request.env.user.has_group(
+            "actividades_complementarias.group_jefe_departamento"
+        ):
+            return {
+                "ok": False,
+                "error": "El perfil Jefe de Departamento no tiene permitido modificar el pase de lista.",
+            }
+
         rec = request.env["actividad.asistencia"].browse(int(asistencia_id))
         if not rec.exists():
             return {"ok": False, "error": "Registro no encontrado."}

--- a/odoo/addons/actividades_complementarias/models/actividad_asistencia.py
+++ b/odoo/addons/actividades_complementarias/models/actividad_asistencia.py
@@ -104,10 +104,22 @@ class ActividadAsistencia(models.Model):
     def write(self, vals):
         """
         Bloquea modificaciones si:
-        1. La actividad ya está finalizada.
-        2. La sesión es anterior a la sesión más reciente de esa actividad.
+        1. El usuario pertenece al grupo Jefe de Departamento.
+        2. La actividad ya está finalizada.
+        3. La sesión es anterior a la sesión más reciente de esa actividad.
            (Solo la sesión más reciente permanece editable.)
         """
+        # Restricción: Jefe de Departamento no puede modificar asistencias
+        if self.env.user.has_group(
+            "actividades_complementarias.group_jefe_departamento"
+        ):
+            raise ValidationError(
+                _(
+                    "El perfil Jefe de Departamento no tiene permitido "
+                    "modificar el pase de lista."
+                )
+            )
+
         for rec in self:
             if rec.actividad_id.estado_code == "finalizada":
                 raise ValidationError(

--- a/odoo/addons/actividades_complementarias/models/actividad_pase_lista_pivot.py
+++ b/odoo/addons/actividades_complementarias/models/actividad_pase_lista_pivot.py
@@ -52,6 +52,9 @@ class ActividadPaseListaPivot(models.TransientModel):
         readonly = (
             actividad.estado_code == "finalizada"
             or actividad.certificates_generated
+            or self.env.user.has_group(
+                "actividades_complementarias.group_jefe_departamento"
+            )
         )
 
         # 1. Todas las fechas únicas de sesión, ordenadas


### PR DESCRIPTION
## Descripción

_¿Qué cambia y por qué? Referencia el caso de uso (ej: implementa E-01SC — inscripción de estudiante)._

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Sin cambio funcional
- [ ] `docs` — Solo documentación
- [ ] `test` — Solo tests
- [ ] `chore` — CI, dependencias, configuración

## Checklist

- [ ] `__manifest__.py` tiene versión correcta y dependencias mínimas
- [ ] Modelos nuevos tienen entradas en `security/ir.model.access.csv`
- [ ] Grupos nuevos están declarados en `security/actividades_security.xml`
- [ ] Si se añade un departamento, se actualizó `DEPT_MAP` en `empleado_permiso.py`
- [ ] Tests pasan localmente (`--test-tags actividades_complementarias`)
- [ ] Linting sin errores (`flake8 --max-line-length=120`)
- [ ] No hay `print()`, TODOs ni código comentado en el diff
- [ ] Si hay cambios de esquema, existe el script de migración en `migrations/`
- [ ] Si se añade dependencia Python, está en `requirements.txt`
